### PR TITLE
feat: support static export for GitHub Pages

### DIFF
--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -1,10 +1,19 @@
+'use client';
 import React, { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import OpportunitiesList from "../../components/OpportunitiesList";
+import OpportunityDetail from "../../components/OpportunityDetail";
+
+function Content() {
+  const searchParams = useSearchParams();
+  const id = searchParams.get('id');
+  return id ? <OpportunityDetail id={id} /> : <OpportunitiesList />;
+}
 
 export default function OpportunitiesPage() {
   return (
     <Suspense fallback={<div className="py-10 text-center" role="status">Loading…</div>}>
-      <OpportunitiesList />
+      <Content />
     </Suspense>
   );
 }

--- a/components/OpportunitiesList.tsx
+++ b/components/OpportunitiesList.tsx
@@ -44,7 +44,9 @@ export default function OpportunitiesList() {
   };
 
   const handleCardClick = (id: string) => {
-    router.push(`/opportunities/${id}?${searchParams.toString()}`);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('id', id);
+    router.push(`/opportunities?${params.toString()}`);
   };
 
   return (

--- a/components/OpportunityDetail.tsx
+++ b/components/OpportunityDetail.tsx
@@ -1,14 +1,12 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Opportunity, fetchOpportunity } from '../../../src/api/opportunities';
+import { Opportunity, fetchOpportunity } from '../src/api/opportunities';
 
-export default function OpportunityDetail() {
-  const params = useParams<{ id: string }>();
+export default function OpportunityDetail({ id }: { id: string }) {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { id } = params;
   const [data, setData] = useState<Opportunity | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -21,7 +19,9 @@ export default function OpportunityDetail() {
       .finally(() => setLoading(false));
   }, [id]);
 
-  const backHref = `/opportunities?${searchParams.toString()}`;
+  const backParams = new URLSearchParams(searchParams.toString());
+  backParams.delete('id');
+  const backHref = `/opportunities?${backParams.toString()}`;
 
   if (loading) return <div className="py-10 text-center" role="status">Loading…</div>;
   if (error) return <div className="py-10 text-center">Failed to load. <button className="underline" onClick={() => router.refresh()}>Retry</button></div>;
@@ -121,3 +121,4 @@ function formatDate(date?: string) {
     return date;
   }
 }
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // Enable static export for deployment on GitHub Pages
+  output: 'export',
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- enable static export in Next.js config for GitHub Pages
- collapse opportunity detail into a query-param view
- add client-side detail component and adjust list navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68972dee599c8333a18f976a39ca2e54