### PR TITLE
feat: add filtering and page size controls

### DIFF
--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -1,0 +1,48 @@
+'use client';
+import React from 'react';
+
+interface FiltersProps {
+  type?: string;
+  city?: string;
+  country?: string;
+  pageLength: number;
+  onChange: (name: string, value: string) => void;
+}
+
+export default function Filters({ type = '', city = '', country = '', pageLength, onChange }: FiltersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <input
+        aria-label="Filter by type"
+        placeholder="Type"
+        className="rounded border px-2 py-1 text-sm"
+        value={type}
+        onChange={(e) => onChange('type', e.target.value)}
+      />
+      <input
+        aria-label="Filter by country"
+        placeholder="Country"
+        className="rounded border px-2 py-1 text-sm"
+        value={country}
+        onChange={(e) => onChange('country', e.target.value)}
+      />
+      <input
+        aria-label="Filter by city"
+        placeholder="City"
+        className="rounded border px-2 py-1 text-sm"
+        value={city}
+        onChange={(e) => onChange('city', e.target.value)}
+      />
+      <select
+        aria-label="Items per page"
+        className="rounded border px-2 py-1 text-sm"
+        value={pageLength}
+        onChange={(e) => onChange('pageLength', e.target.value)}
+      >
+        <option value="6">6</option>
+        <option value="12">12</option>
+        <option value="24">24</option>
+      </select>
+    </div>
+  );
+}

--- a/components/OpportunitiesList.tsx
+++ b/components/OpportunitiesList.tsx
@@ -6,12 +6,17 @@ import OpportunityCard from './OpportunityCard';
 import SkeletonCard from './SkeletonCard';
 import Pagination from './Pagination';
 import SortSelect from './SortSelect';
+import Filters from './Filters';
 
 export default function OpportunitiesList() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const sortBy = searchParams.get('sortBy') || '-deadline';
   const page = parseInt(searchParams.get('page') || '1', 10);
+  const type = searchParams.get('type') || '';
+  const country = searchParams.get('country') || '';
+  const city = searchParams.get('city') || '';
+  const pageLength = parseInt(searchParams.get('pageLength') || '6', 10);
 
   const [data, setData] = useState<OpportunityListResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -20,11 +25,11 @@ export default function OpportunitiesList() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetchOpportunities({ sortBy, page })
+    fetchOpportunities({ sortBy, page, type, country, city, pageLength })
       .then((res) => setData(res))
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [sortBy, page]);
+  }, [sortBy, page, type, country, city, pageLength]);
 
   const updateParams = (params: URLSearchParams) => {
     router.push(`/opportunities?${params.toString()}`);
@@ -33,6 +38,17 @@ export default function OpportunitiesList() {
   const handleSortChange = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('sortBy', value);
+    params.set('page', '1');
+    updateParams(params);
+  };
+
+  const handleFilterChange = (name: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(name, value);
+    } else {
+      params.delete(name);
+    }
     params.set('page', '1');
     updateParams(params);
   };
@@ -51,8 +67,17 @@ export default function OpportunitiesList() {
 
   return (
     <div>
-      <div className="mb-4 flex items-center justify-end">
-        <SortSelect value={sortBy} onChange={handleSortChange} />
+      <div className="mb-4 flex flex-col gap-2">
+        <Filters
+          type={type}
+          country={country}
+          city={city}
+          pageLength={pageLength}
+          onChange={handleFilterChange}
+        />
+        <div className="flex items-center justify-end">
+          <SortSelect value={sortBy} onChange={handleSortChange} />
+        </div>
       </div>
       {error && (
         <div className="mb-4 rounded border border-red-200 bg-red-50 p-4">
@@ -68,7 +93,7 @@ export default function OpportunitiesList() {
       )}
       {loading ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, i) => (
+          {Array.from({ length: pageLength }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>

--- a/src/api/opportunities.ts
+++ b/src/api/opportunities.ts
@@ -59,10 +59,23 @@ export type OpportunityListResponse = {
 
 const API = "https://api.artconnect.com/v1";
 
-export async function fetchOpportunities(params: { sortBy?: string; page?: number } = {}): Promise<OpportunityListResponse> {
+export async function fetchOpportunities(
+  params: {
+    sortBy?: string;
+    page?: number;
+    type?: string;
+    country?: string;
+    city?: string;
+    pageLength?: number;
+  } = {}
+): Promise<OpportunityListResponse> {
   const url = new URL(API + "/opportunities/");
   if (params.sortBy) url.searchParams.set("sortBy", params.sortBy);
   if (params.page) url.searchParams.set("page", String(params.page));
+  if (params.type) url.searchParams.set("type", params.type);
+  if (params.country) url.searchParams.set("country", params.country);
+  if (params.city) url.searchParams.set("city", params.city);
+  if (params.pageLength) url.searchParams.set("pageLength", String(params.pageLength));
   const res = await fetch(url.toString(), { headers: { Accept: "application/json" } });
   if (!res.ok) throw new Error(`List fetch failed: ${res.status}`);
   return (await res.json()) as OpportunityListResponse;


### PR DESCRIPTION
## Summary
- add type, country, and city filters plus page size selector
- include new filter component and wire into opportunities list
- extend API helper to pass filtering and page length params

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68973cff90908333ac48bd96b9034b81