### PR TITLE
Add typeahead search for opportunities

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import Link from "next/link";
 import React from "react";
+import SearchBar from "../components/SearchBar";
 
 export const metadata = {
   title: "ArtConnect Opportunities",
@@ -16,13 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <Link href="/opportunities" className="text-xl font-semibold">
               Opportunities
             </Link>
-            <input
-              type="text"
-              placeholder="Search..."
-              className="w-48 rounded border px-3 py-1 text-sm"
-              aria-label="Search opportunities"
-              disabled
-            />
+            <SearchBar />
           </div>
         </header>
         <main className="mx-auto max-w-5xl p-4">{children}</main>

--- a/components/OpportunitiesList.tsx
+++ b/components/OpportunitiesList.tsx
@@ -22,6 +22,7 @@ export default function OpportunitiesList() {
   const typeParam = searchParams.get('type') || '';
   const countryParam = searchParams.get('country') || '';
   const cityParam = searchParams.get('city') || '';
+  const searchQuery = searchParams.get('search') || '';
   const type = useMemo(() => (typeParam ? typeParam.split(',').filter(Boolean) : []), [typeParam]);
   const country = useMemo(() => (countryParam ? countryParam.split(',').filter(Boolean) : []), [countryParam]);
   const city = useMemo(() => (cityParam ? cityParam.split(',').filter(Boolean) : []), [cityParam]);
@@ -68,11 +69,11 @@ export default function OpportunitiesList() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetchOpportunities({ sortBy, page, type, country, city, pageLength })
+    fetchOpportunities({ sortBy, page, type, country, city, pageLength, search: searchQuery })
       .then((res) => setData(res))
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [sortBy, page, type, country, city, pageLength]);
+  }, [sortBy, page, type, country, city, pageLength, searchQuery]);
 
   const updateParams = (params: URLSearchParams) => {
     router.push(`/opportunities?${params.toString()}`);

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,74 @@
+'use client';
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { fetchOpportunities, Opportunity } from '../src/api/opportunities';
+
+export default function SearchBar() {
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<Opportunity[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    let active = true;
+    if (!query) {
+      setSuggestions([]);
+      return;
+    }
+    async function load() {
+      try {
+        const res = await fetchOpportunities({ search: query, pageLength: 5 });
+        if (active) setSuggestions(res.data);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    load();
+    return () => {
+      active = false;
+    };
+  }, [query]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (query.trim()) {
+      router.push(`/opportunities?search=${encodeURIComponent(query.trim())}`);
+      setSuggestions([]);
+    }
+  };
+
+  const handleSelect = (id: string) => {
+    router.push(`/opportunities?id=${encodeURIComponent(id)}`);
+    setSuggestions([]);
+    setQuery('');
+  };
+
+  return (
+    <div className="relative">
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search..."
+          className="w-48 rounded border px-3 py-1 text-sm"
+          aria-label="Search opportunities"
+        />
+      </form>
+      {suggestions.length > 0 && (
+        <ul className="absolute z-10 mt-1 w-48 rounded border bg-white text-sm">
+          {suggestions.map((s) => (
+            <li key={s.id}>
+              <button
+                className="block w-full px-3 py-1 text-left hover:bg-gray-100"
+                onClick={() => handleSelect(s.id)}
+              >
+                {s.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/api/opportunities.ts
+++ b/src/api/opportunities.ts
@@ -67,6 +67,7 @@ export async function fetchOpportunities(
     country?: string | string[];
     city?: string | string[];
     pageLength?: number;
+    search?: string;
   } = {},
 ): Promise<OpportunityListResponse> {
   const url = new URL(API + "/opportunities/");
@@ -85,6 +86,7 @@ export async function fetchOpportunities(
     url.searchParams.set("city", value);
   }
   if (params.pageLength !== undefined) url.searchParams.set("pageLength", String(params.pageLength));
+  if (params.search) url.searchParams.set("search", params.search);
   const res = await fetch(url.toString(), { headers: { Accept: "application/json" } });
   if (!res.ok) throw new Error(`List fetch failed: ${res.status}`);
   return (await res.json()) as OpportunityListResponse;


### PR DESCRIPTION
## Summary
- implement client SearchBar with suggestions
- extend API and list to support search query

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c5c161f083338b115cf942d91323