### PR TITLE
Add interactive MusicDiscovery experience

### DIFF
--- a/app/projects/music-discovery/client/MusicDiscoveryExperience.tsx
+++ b/app/projects/music-discovery/client/MusicDiscoveryExperience.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ReactMarkdown from 'react-markdown';
+import SearchBar from './components/SearchBar';
+import GraphCanvas from './components/GraphCanvas';
+import GlobalPlayer from './components/GlobalPlayer';
+import SidePanel from './components/SidePanel';
+import { AuthProvider } from './lib/auth';
+import styles from './styles.module.css';
+
+const tabs = [
+  { id: 'app', label: 'Interactieve app' },
+  { id: 'blueprint', label: 'Blueprint' },
+] as const;
+
+type Tab = (typeof tabs)[number]['id'];
+
+type Props = { blueprint: string };
+
+function ExperienceShell({ blueprint }: Props) {
+  const [tab, setTab] = useState<Tab>('app');
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-slate-100">MusicDiscovery Experience</h2>
+        <div className={styles.tabs}>
+          {tabs.map((item) => (
+            <button
+              key={item.id}
+              className={`${styles.tabButton} ${tab === item.id ? styles.tabButtonActive : ''}`}
+              onClick={() => setTab(item.id)}
+              type="button"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {tab === 'app' ? (
+        <div className={styles.app}>
+          <header className={styles.header}>
+            <div className={styles.logo}>MusicDiscovery</div>
+            <SearchBar />
+            <nav style={{ display: 'flex', gap: 10 }}>
+              <a className={styles.btn} href="#">Home</a>
+              <a className={styles.btn} href="#discover">Discover</a>
+              <a className={styles.btn} href="#library">Library</a>
+            </nav>
+          </header>
+          <main className={styles.main}>
+            <div className={styles.canvasWrap}>
+              <GraphCanvas />
+            </div>
+            <SidePanel />
+          </main>
+          <footer className={styles.footer}>
+            <div>
+              <div className={styles.label}>Global player</div>
+              <div style={{ color: 'white', fontWeight: 600 }}>Luister 30s previews</div>
+            </div>
+            <GlobalPlayer />
+          </footer>
+        </div>
+      ) : (
+        <article className={styles.blueprint}>
+          <ReactMarkdown>{blueprint}</ReactMarkdown>
+        </article>
+      )}
+    </div>
+  );
+}
+
+export default function MusicDiscoveryExperience({ blueprint }: Props) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <ExperienceShell blueprint={blueprint} />
+      </QueryClientProvider>
+    </AuthProvider>
+  );
+}

--- a/app/projects/music-discovery/client/components/ContextMenu.tsx
+++ b/app/projects/music-discovery/client/components/ContextMenu.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import styles from '../styles.module.css';
+
+type MenuItem = { label: string; onClick: () => void; disabled?: boolean };
+
+type Props = {
+  x: number;
+  y: number;
+  title?: string;
+  items: MenuItem[];
+  onClose: () => void;
+};
+
+export function ContextMenu({ x, y, title, items, onClose }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [onClose]);
+
+  return (
+    <div ref={ref} className={styles.menu} style={{ left: x, top: y }}>
+      {title && <div className={styles.menuTitle}>{title}</div>}
+      {items.map((item, index) => (
+        <button
+          key={index}
+          className={styles.menuButton}
+          onClick={() => {
+            if (item.disabled) return;
+            onClose();
+            item.onClick();
+          }}
+          disabled={item.disabled}
+          style={{ opacity: item.disabled ? 0.5 : 1 }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/projects/music-discovery/client/components/FavoriteButton.tsx
+++ b/app/projects/music-discovery/client/components/FavoriteButton.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '../lib/auth';
+import { Api } from '../lib/api';
+import { useGraphStore } from '../store/graphStore';
+import styles from '../styles.module.css';
+
+export default function FavoriteButton() {
+  const { token, refreshFavorites } = useAuth();
+  const node = useGraphStore((state) => {
+    if (state.selectedNodeId) {
+      return state.nodes.find((item) => item.id === state.selectedNodeId);
+    }
+    if (state.pivotNodeId) {
+      return state.nodes.find((item) => item.id === state.pivotNodeId);
+    }
+    return undefined;
+  });
+  const [status, setStatus] = useState<'idle' | 'saved'>('idle');
+
+  const save = async () => {
+    if (!node || !token) return;
+    await Api.addFavorite(token, {
+      artistId: node.artistId,
+      name: node.name,
+      imageUrl: node.imageUrl,
+    });
+    setStatus('saved');
+    await refreshFavorites();
+    setTimeout(() => setStatus('idle'), 2400);
+  };
+
+  if (!node) return null;
+
+  return (
+    <button className={styles.btn} onClick={save} disabled={!token}>
+      {status === 'saved' ? 'Bewaard' : 'Favoriet'}
+    </button>
+  );
+}

--- a/app/projects/music-discovery/client/components/GlobalPlayer.tsx
+++ b/app/projects/music-discovery/client/components/GlobalPlayer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { globalAudio } from '../lib/audio';
+import styles from '../styles.module.css';
+
+export default function GlobalPlayer() {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const unsubscribe = globalAudio.onChange(() => setTick((value) => value + 1));
+    return unsubscribe;
+  }, []);
+
+  return (
+    <div className={styles.footerPlayer}>
+      <button className={styles.btn} onClick={() => globalAudio.pause()}>
+        Pauzeer
+      </button>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        defaultValue={0.8}
+        className={styles.range}
+        onChange={(event) => globalAudio.volume(Number(event.target.value))}
+      />
+    </div>
+  );
+}

--- a/app/projects/music-discovery/client/components/GraphCanvas.tsx
+++ b/app/projects/music-discovery/client/components/GraphCanvas.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import type { ForceGraphMethods } from 'react-force-graph-2d';
+import { useGraphStore } from '../store/graphStore';
+import { drawCircularImage } from './NodeImage';
+import { Api } from '../lib/api';
+import { globalAudio } from '../lib/audio';
+import { ContextMenu } from './ContextMenu';
+import styles from '../styles.module.css';
+
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), { ssr: false });
+
+type MenuState = { x: number; y: number; nodeId: string } | null;
+
+export default function GraphCanvas() {
+  const { nodes, edges, pivotNodeId, setPivot, addNeighbors, setSelected } = useGraphStore();
+  const graphRef = useRef<ForceGraphMethods>();
+  const [menu, setMenu] = useState<MenuState>(null);
+  const imageCache = useMemo(() => new Map<string, HTMLImageElement>(), []);
+
+  const graphData = useMemo(() => ({ nodes, links: edges }), [nodes, edges]);
+
+  const getImage = (url?: string) => {
+    if (!url) return undefined;
+    if (imageCache.has(url)) {
+      return imageCache.get(url);
+    }
+    const img = new Image();
+    img.src = url;
+    imageCache.set(url, img);
+    return img;
+  };
+
+  useEffect(() => {
+    if (!pivotNodeId || !graphRef.current) return;
+    const node = nodes.find((item) => item.id === pivotNodeId);
+    if (node) {
+      graphRef.current.centerAt(node.x ?? 0, node.y ?? 0, 800);
+      graphRef.current.zoom(1.5, 800);
+    }
+  }, [pivotNodeId, nodes]);
+
+  return (
+    <div className={styles.canvasWrap} onContextMenu={(event) => event.preventDefault()}>
+      <ForceGraph2D
+        ref={graphRef as any}
+        graphData={graphData as any}
+        nodeRelSize={6}
+        linkColor={() => '#3a4460'}
+        linkWidth={1}
+        cooldownTicks={60}
+        enableNodeDrag
+        backgroundColor="rgba(10,12,20,0)"
+        onNodeClick={(node: any, event) => {
+          const mouse = event as MouseEvent;
+          setSelected(node.id);
+          setMenu({ x: mouse.clientX, y: mouse.clientY, nodeId: node.id });
+        }}
+        onNodeRightClick={(node: any, event) => {
+          event.preventDefault();
+          const mouse = event as MouseEvent;
+          setSelected(node.id);
+          setMenu({ x: mouse.clientX, y: mouse.clientY, nodeId: node.id });
+        }}
+        onBackgroundClick={() => setMenu(null)}
+        nodeCanvasObject={(node: any, ctx, globalScale) => {
+          const radius = 26;
+          const img = getImage(node.imageUrl);
+          if (img) {
+            drawCircularImage(ctx, img, node.x, node.y, radius);
+          } else {
+            ctx.beginPath();
+            ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+            ctx.fillStyle = '#233152';
+            ctx.fill();
+          }
+          ctx.font = `${12 / Math.max(globalScale, 1)}px 'Inter', sans-serif`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'top';
+          ctx.fillStyle = 'rgba(230,233,239,0.95)';
+          ctx.fillText(node.name, node.x, node.y + radius + 6);
+        }}
+      />
+
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          title={useGraphStore.getState().nodes.find((n) => n.id === menu.nodeId)?.name}
+          onClose={() => setMenu(null)}
+          items={[
+            {
+              label: 'Meer gelijkaardige artiesten',
+              onClick: async () => {
+                const pivot = useGraphStore.getState().nodes.find((n) => n.id === menu.nodeId);
+                if (!pivot) return;
+                setPivot(pivot.id);
+                const related = await Api.getRelated(pivot.artistId);
+                addNeighbors(pivot.id, related);
+              },
+            },
+            {
+              label: 'Luister preview',
+              onClick: async () => {
+                const pivot = useGraphStore.getState().nodes.find((n) => n.id === menu.nodeId);
+                if (!pivot) return;
+                const tracks = await Api.getTopTracks(pivot.artistId);
+                const playable = tracks.find((track) => track.previewUrl);
+                if (playable) {
+                  globalAudio.play(playable.id, playable.previewUrl);
+                }
+              },
+            },
+          ]}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/projects/music-discovery/client/components/NodeImage.ts
+++ b/app/projects/music-discovery/client/components/NodeImage.ts
@@ -1,0 +1,9 @@
+export function drawCircularImage(ctx: CanvasRenderingContext2D, img: HTMLImageElement, x: number, y: number, radius: number) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.clip();
+  ctx.drawImage(img, x - radius, y - radius, radius * 2, radius * 2);
+  ctx.restore();
+}

--- a/app/projects/music-discovery/client/components/SearchBar.tsx
+++ b/app/projects/music-discovery/client/components/SearchBar.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+import { Api } from '../lib/api';
+import { useGraphStore } from '../store/graphStore';
+import styles from '../styles.module.css';
+
+export default function SearchBar() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+  const [open, setOpen] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const upsertRoot = useGraphStore((state) => state.upsertRoot);
+  const addNeighbors = useGraphStore((state) => state.addNeighbors);
+
+  useEffect(() => {
+    const handle = setTimeout(async () => {
+      if (query.trim().length < 2) {
+        setResults([]);
+        setOpen(false);
+        return;
+      }
+      const response = await Api.searchArtists(query.trim(), 8);
+      setResults(response);
+      setOpen(true);
+    }, 220);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const choose = async (artist: any) => {
+    const nodeId = upsertRoot({ id: artist.id, name: artist.name, imageUrl: artist.imageUrl });
+    const related = await Api.getRelated(artist.id);
+    addNeighbors(nodeId, related);
+    setOpen(false);
+    setQuery(artist.name);
+  };
+
+  return (
+    <div className={styles.search}>
+      <input
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Zoek artiest of band..."
+        className={styles.searchInput}
+        onFocus={() => results.length && setOpen(true)}
+        onBlur={() => {
+          setTimeout(() => setOpen(false), 120);
+        }}
+      />
+      {open && results.length > 0 && (
+        <div ref={listRef} className={styles.searchList}>
+          {results.map((item) => (
+            <button key={item.id} onMouseDown={() => choose(item)} className={styles.track} style={{ border: 'none', background: 'transparent', textAlign: 'left', width: '100%' }}>
+              {item.imageUrl && (
+                <Image
+                  src={item.imageUrl}
+                  width={40}
+                  height={40}
+                  style={{ borderRadius: 12, objectFit: 'cover' }}
+                  alt={item.name}
+                />
+              )}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 600 }}>{item.name}</div>
+                {item.genres?.length ? (
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 4 }}>
+                    {item.genres.slice(0, 3).map((genre: string) => (
+                      <span key={genre} className={styles.chip}>
+                        {genre}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <small>Artiest</small>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/projects/music-discovery/client/components/SidePanel.tsx
+++ b/app/projects/music-discovery/client/components/SidePanel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import FavoriteButton from './FavoriteButton';
+import SnapshotDialog from './SnapshotDialog';
+import TopTracks from './TopTracks';
+import { useAuth } from '../lib/auth';
+import { Api } from '../lib/api';
+import styles from '../styles.module.css';
+
+export default function SidePanel() {
+  const { token, favorites } = useAuth();
+  const [snapshots, setSnapshots] = useState<{ title: string; graphJson: any }[]>([]);
+
+  useEffect(() => {
+    if (!token) {
+      setSnapshots([]);
+      return;
+    }
+    Api.listSnapshots(token).then((items) => setSnapshots(items ?? []));
+  }, [token]);
+
+  useEffect(() => {
+    const handler = () => {
+      if (token) {
+        Api.listSnapshots(token).then((items) => setSnapshots(items ?? []));
+      }
+    };
+    window.addEventListener('musicdiscovery:snapshot-created', handler);
+    return () => window.removeEventListener('musicdiscovery:snapshot-created', handler);
+  }, [token]);
+
+  return (
+    <aside className={styles.side}>
+      <div className={styles.sideSection}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <FavoriteButton />
+          <SnapshotDialog />
+        </div>
+        <div className={styles.label}>Pin, bewaar en deel je graaf.</div>
+      </div>
+      <TopTracks />
+      <div className={styles.sideSection}>
+        <div className={styles.sideSectionHeader}>Favorieten</div>
+        {favorites.length === 0 ? (
+          <div className={styles.label}>Nog geen favorieten toegevoegd.</div>
+        ) : (
+          <div className={styles.snapshotList}>
+            {favorites.map((fav) => (
+              <div key={fav.artistId} className={styles.snapshotCard}>
+                <div>
+                  <div className={styles.snapshotTitle}>{fav.name}</div>
+                  <div className={styles.label}>Artiest</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className={styles.sideSection}>
+        <div className={styles.sideSectionHeader}>Snapshots</div>
+        {snapshots.length === 0 ? (
+          <div className={styles.label}>Sla een snapshot op om je graaf later terug te openen.</div>
+        ) : (
+          <div className={styles.snapshotList}>
+            {snapshots.map((snapshot, index) => (
+              <div key={`${snapshot.title}-${index}`} className={styles.snapshotCard}>
+                <div>
+                  <div className={styles.snapshotTitle}>{snapshot.title}</div>
+                  <div className={styles.label}>{snapshot.graphJson?.nodes?.length ?? 0} nodes</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/app/projects/music-discovery/client/components/SnapshotDialog.tsx
+++ b/app/projects/music-discovery/client/components/SnapshotDialog.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useGraphStore } from '../store/graphStore';
+import { Api } from '../lib/api';
+import { useAuth } from '../lib/auth';
+import styles from '../styles.module.css';
+
+export default function SnapshotDialog() {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('Mijn snapshot');
+  const { token, refreshFavorites } = useAuth();
+  const graph = useGraphStore((state) => ({
+    nodes: state.nodes,
+    edges: state.edges,
+    pivotNodeId: state.pivotNodeId,
+  }));
+
+  const snapshotDisabled = useMemo(() => graph.nodes.length === 0, [graph.nodes.length]);
+
+  const save = async () => {
+    if (!token || snapshotDisabled) return;
+    await Api.createSnapshot(token, { title, graphJson: graph });
+    setOpen(false);
+    await refreshFavorites();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('musicdiscovery:snapshot-created'));
+    }
+  };
+
+  return (
+    <>
+      <button className={styles.btn} onClick={() => setOpen(true)} disabled={!token || snapshotDisabled}>
+        Snapshot
+      </button>
+      {open && (
+        <div className={styles.dialogBackdrop}>
+          <div className={styles.dialog}>
+            <h3 className={styles.dialogTitle}>Snapshot opslaan</h3>
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className={styles.dialogInput}
+              placeholder="Naam van je snapshot"
+            />
+            <div className={styles.dialogActions}>
+              <button className={styles.btn} onClick={() => setOpen(false)}>
+                Annuleer
+              </button>
+              <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={save}>
+                Opslaan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/projects/music-discovery/client/components/TopTracks.tsx
+++ b/app/projects/music-discovery/client/components/TopTracks.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Api } from '../lib/api';
+import { useGraphStore } from '../store/graphStore';
+import { formatMs } from '../lib/format';
+import { globalAudio } from '../lib/audio';
+import styles from '../styles.module.css';
+
+export default function TopTracks() {
+  const node = useGraphStore((state) => {
+    if (state.selectedNodeId) {
+      return state.nodes.find((item) => item.id === state.selectedNodeId);
+    }
+    if (state.pivotNodeId) {
+      return state.nodes.find((item) => item.id === state.pivotNodeId);
+    }
+    return undefined;
+  });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const unsubscribe = globalAudio.onChange(() => setTick((value) => value + 1));
+    return unsubscribe;
+  }, []);
+
+  const market = useMemo(() => (typeof window !== 'undefined' ? window.navigator.language.slice(0, 2).toUpperCase() : 'BE'), []);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['top-tracks', node?.artistId, market],
+    queryFn: () => Api.getTopTracks(node!.artistId, market),
+    enabled: !!node,
+  });
+
+  if (!node) {
+    return <div className={styles.sideSection}>Selecteer een artiest in de graaf om top tracks te zien.</div>;
+  }
+
+  return (
+    <div className={styles.sideSection}>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        {node.imageUrl && (
+          <Image src={node.imageUrl} width={64} height={64} style={{ borderRadius: 16 }} alt={node.name} />
+        )}
+        <div>
+          <div style={{ fontWeight: 700, fontSize: 16 }}>{node.name}</div>
+          <div className={styles.label}>Top tracks</div>
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {isLoading && <div className={styles.label}>Laden...</div>}
+        {(data || []).map((track) => (
+          <div key={track.id} className={styles.track} style={{ background: 'rgba(12,16,26,0.55)' }}>
+            <button
+              className={`${styles.btn} ${styles.btnPrimary}`}
+              onClick={() => globalAudio.play(track.id, track.previewUrl)}
+              disabled={!track.previewUrl}
+            >
+              {globalAudio.isPlaying(track.id) ? 'Pause' : 'Play'}
+            </button>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontWeight: 600 }}>{track.name}</div>
+              <small>{formatMs(track.durationMs)}</small>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/projects/music-discovery/client/lib/api.ts
+++ b/app/projects/music-discovery/client/lib/api.ts
@@ -1,0 +1,130 @@
+'use client';
+
+import axios from 'axios';
+import {
+  mockAddFavorite,
+  mockCreateSnapshot,
+  mockFavorites,
+  mockRelated,
+  mockSearch,
+  mockSnapshots,
+  mockTopTracks,
+  mockUser,
+} from './mock-data';
+import type { Artist, Track } from './types';
+
+const envBase = process.env.NEXT_PUBLIC_API_BASE;
+const baseURL = envBase && envBase.trim().length > 0 ? envBase : null;
+const http = baseURL
+  ? axios.create({
+      baseURL: baseURL.endsWith('/api') ? baseURL : `${baseURL.replace(/\/$/, '')}/api`,
+      withCredentials: true,
+    })
+  : null;
+
+type ApiList<T> = { items: T[] };
+
+async function withFallback<T>(action: () => Promise<T>, fallback: () => Promise<T>): Promise<T> {
+  if (!http) return fallback();
+  try {
+    return await action();
+  } catch (error) {
+    console.warn('[MusicDiscovery] API request failed, falling back to mock data.', error);
+    return fallback();
+  }
+}
+
+export const Api = {
+  async anonymousAuth() {
+    if (!http) return mockUser;
+    try {
+      const res = await http.post('/auth/anonymous');
+      return res.data as { token: string; user: any };
+    } catch (error) {
+      console.warn('[MusicDiscovery] Anonymous auth failed, using demo token.', error);
+      return mockUser;
+    }
+  },
+
+  async searchArtists(query: string, limit = 10) {
+    return withFallback(
+      async () => {
+        const res = await http!.get<ApiList<Artist>>('/spotify/search', { params: { query, limit } });
+        return res.data.items;
+      },
+      () => mockSearch(query, limit),
+    );
+  },
+
+  async getRelated(id: string) {
+    return withFallback(
+      async () => {
+        const res = await http!.get<ApiList<Artist>>(`/spotify/artists/${id}/related`);
+        return res.data.items;
+      },
+      () => mockRelated(id),
+    );
+  },
+
+  async getTopTracks(id: string, market?: string) {
+    return withFallback(
+      async () => {
+        const res = await http!.get<ApiList<Track>>(`/spotify/artists/${id}/top-tracks`, { params: { market } });
+        return res.data.items;
+      },
+      () => mockTopTracks(id),
+    );
+  },
+
+  async favorites(token: string) {
+    return withFallback(
+      async () => {
+        const res = await http!.get<ApiList<any>>('/favorites', { headers: { Authorization: `Bearer ${token}` } });
+        return res.data.items;
+      },
+      () => mockFavorites(token),
+    );
+  },
+
+  async addFavorite(token: string, body: { artistId: string; name: string; imageUrl?: string }) {
+    if (!http) {
+      await mockAddFavorite(token, body);
+      return body;
+    }
+    try {
+      const res = await http.post('/favorites', body, { headers: { Authorization: `Bearer ${token}` } });
+      return res.data;
+    } catch (error) {
+      console.warn('[MusicDiscovery] Failed to persist favorite, storing locally.', error);
+      await mockAddFavorite(token, body);
+      return body;
+    }
+  },
+
+  async listSnapshots(token: string) {
+    return withFallback(
+      async () => {
+        const res = await http!.get<ApiList<any>>('/snapshots', { headers: { Authorization: `Bearer ${token}` } });
+        return res.data.items;
+      },
+      () => mockSnapshots(token),
+    );
+  },
+
+  async createSnapshot(token: string, body: { title: string; graphJson: any; previewUrl?: string }) {
+    if (!http) {
+      await mockCreateSnapshot(token, body);
+      return body;
+    }
+    try {
+      const res = await http.post('/snapshots', body, { headers: { Authorization: `Bearer ${token}` } });
+      return res.data;
+    } catch (error) {
+      console.warn('[MusicDiscovery] Failed to persist snapshot, storing locally.', error);
+      await mockCreateSnapshot(token, body);
+      return body;
+    }
+  },
+};
+
+export type { Artist, Track };

--- a/app/projects/music-discovery/client/lib/audio.ts
+++ b/app/projects/music-discovery/client/lib/audio.ts
@@ -1,0 +1,64 @@
+class GlobalAudio {
+  private audio: HTMLAudioElement | null = null;
+  private current?: { id: string; url: string };
+  private listeners = new Set<() => void>();
+
+  private ensureAudio() {
+    if (!this.audio) {
+      this.audio = new Audio();
+      this.audio.volume = 0.8;
+      this.audio.addEventListener('ended', () => this.emit());
+      this.audio.addEventListener('pause', () => this.emit());
+    }
+    return this.audio;
+  }
+
+  play(id: string, url?: string) {
+    if (!url) return;
+    const audio = this.ensureAudio();
+
+    if (this.current?.id === id && !audio.paused) {
+      audio.pause();
+      this.emit();
+      return;
+    }
+
+    if (this.current?.id !== id) {
+      audio.src = url;
+    }
+
+    this.current = { id, url };
+    void audio.play();
+    this.emit();
+  }
+
+  pause() {
+    const audio = this.ensureAudio();
+    audio.pause();
+    this.emit();
+  }
+
+  isPlaying(id?: string) {
+    const audio = this.ensureAudio();
+    return !!this.current && this.current.id === id && !audio.paused;
+  }
+
+  volume(value: number) {
+    const audio = this.ensureAudio();
+    audio.volume = value;
+    this.emit();
+  }
+
+  onChange(listener: () => void) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit() {
+    this.listeners.forEach((listener) => listener());
+  }
+}
+
+export const globalAudio = new GlobalAudio();

--- a/app/projects/music-discovery/client/lib/auth.tsx
+++ b/app/projects/music-discovery/client/lib/auth.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { Api } from './api';
+
+type AuthState = {
+  token: string | null;
+  setToken: (token: string | null) => void;
+  favorites: { artistId: string; name: string; imageUrl?: string }[];
+  refreshFavorites: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthState>({
+  token: null,
+  setToken: () => {},
+  favorites: [],
+  refreshFavorites: async () => {},
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [favorites, setFavorites] = useState<AuthState['favorites']>([]);
+
+  const refreshFavorites = useMemo(
+    () =>
+      async () => {
+        if (!token) {
+          setFavorites([]);
+          return;
+        }
+        const list = await Api.favorites(token);
+        setFavorites(list);
+      },
+    [token],
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    const hashToken = params.get('token');
+    if (hashToken) {
+      setToken(hashToken);
+      window.localStorage.setItem('musicdiscovery.token', hashToken);
+      window.location.hash = '';
+      return;
+    }
+
+    const stored = window.localStorage.getItem('musicdiscovery.token');
+    if (stored) {
+      setToken(stored);
+      return;
+    }
+
+    Api.anonymousAuth().then((response) => {
+      setToken(response.token);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('musicdiscovery.token', response.token);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    void refreshFavorites();
+  }, [refreshFavorites]);
+
+  const value = useMemo(
+    () => ({ token, setToken, favorites, refreshFavorites }),
+    [token, favorites, refreshFavorites],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/app/projects/music-discovery/client/lib/format.ts
+++ b/app/projects/music-discovery/client/lib/format.ts
@@ -1,0 +1,6 @@
+export function formatMs(durationMs: number) {
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`;
+}

--- a/app/projects/music-discovery/client/lib/mock-data.ts
+++ b/app/projects/music-discovery/client/lib/mock-data.ts
@@ -1,0 +1,234 @@
+import { Artist, Track } from './types';
+
+type MockGraph = {
+  artist: Artist;
+  related: string[];
+  topTracks: Track[];
+};
+
+const previewUrl =
+  'https://cdn.pixabay.com/download/audio/2021/09/01/audio_c3617c4a68.mp3?filename=ambient-110734.mp3';
+
+const ARTISTS: Record<string, MockGraph> = {
+  'tame-impala': {
+    artist: {
+      id: 'tame-impala',
+      name: 'Tame Impala',
+      imageUrl:
+        'https://images.unsplash.com/photo-1501612780327-45045538702b?auto=format&fit=crop&w=256&q=80',
+      genres: ['psychedelic pop', 'australian psych'],
+      popularity: 85,
+    },
+    related: ['pond', 'unknown-mortal-orchestra', 'mgmt', 'khruangbin', 'jungle'],
+    topTracks: [
+      { id: 'elephant', name: 'Elephant', durationMs: 234000, previewUrl, artists: [{ id: 'tame-impala', name: 'Tame Impala' }] },
+      { id: 'let-it-happen', name: 'Let It Happen', durationMs: 332000, previewUrl, artists: [{ id: 'tame-impala', name: 'Tame Impala' }] },
+      { id: 'the-less-i-know-the-better', name: 'The Less I Know the Better', durationMs: 216000, previewUrl, artists: [{ id: 'tame-impala', name: 'Tame Impala' }] },
+    ],
+  },
+  pond: {
+    artist: {
+      id: 'pond',
+      name: 'POND',
+      imageUrl:
+        'https://images.unsplash.com/photo-1521334884684-d80222895322?auto=format&fit=crop&w=256&q=80',
+      genres: ['psych rock', 'perth indie'],
+      popularity: 64,
+    },
+    related: ['tame-impala', 'king-gizzard', 'melody-prose', 'unknown-mortal-orchestra'],
+    topTracks: [
+      { id: 'daisy', name: 'Daisy', durationMs: 248000, previewUrl, artists: [{ id: 'pond', name: 'POND' }] },
+      { id: 'paint-me-silver', name: 'Paint Me Silver', durationMs: 258000, previewUrl, artists: [{ id: 'pond', name: 'POND' }] },
+    ],
+  },
+  'unknown-mortal-orchestra': {
+    artist: {
+      id: 'unknown-mortal-orchestra',
+      name: 'Unknown Mortal Orchestra',
+      imageUrl:
+        'https://images.unsplash.com/photo-1529158062015-cad636e69505?auto=format&fit=crop&w=256&q=80',
+      genres: ['lo-fi psych', 'portland indie'],
+      popularity: 70,
+    },
+    related: ['tame-impala', 'khruangbin', 'mild-high-club', 'king-gizzard'],
+    topTracks: [
+      { id: 'honeybee', name: 'Hunnybee', durationMs: 269000, previewUrl, artists: [{ id: 'unknown-mortal-orchestra', name: 'Unknown Mortal Orchestra' }] },
+      { id: 'multi-love', name: 'Multi-Love', durationMs: 260000, previewUrl, artists: [{ id: 'unknown-mortal-orchestra', name: 'Unknown Mortal Orchestra' }] },
+    ],
+  },
+  khruangbin: {
+    artist: {
+      id: 'khruangbin',
+      name: 'Khruangbin',
+      imageUrl:
+        'https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?auto=format&fit=crop&w=256&q=80',
+      genres: ['psychedelic soul', 'thai funk'],
+      popularity: 80,
+    },
+    related: ['men-i-trust', 'unknown-mortal-orchestra', 'mild-high-club', 'jungle'],
+    topTracks: [
+      { id: 'people-everywhere', name: 'People Everywhere (Still Alive)', durationMs: 275000, previewUrl, artists: [{ id: 'khruangbin', name: 'Khruangbin' }] },
+      { id: 'time-you-and-i', name: 'Time (You and I)', durationMs: 312000, previewUrl, artists: [{ id: 'khruangbin', name: 'Khruangbin' }] },
+    ],
+  },
+  jungle: {
+    artist: {
+      id: 'jungle',
+      name: 'Jungle',
+      imageUrl:
+        'https://images.unsplash.com/photo-1529158062209-c095a807b3d5?auto=format&fit=crop&w=256&q=80',
+      genres: ['modern soul', 'uk funk'],
+      popularity: 82,
+    },
+    related: ['parcels', 'men-i-trust', 'khruangbin', 'glass-animals'],
+    topTracks: [
+      { id: 'busy-earnin', name: "Busy Earnin'", durationMs: 207000, previewUrl, artists: [{ id: 'jungle', name: 'Jungle' }] },
+      { id: 'keep-moving', name: 'Keep Moving', durationMs: 217000, previewUrl, artists: [{ id: 'jungle', name: 'Jungle' }] },
+    ],
+  },
+  parcels: {
+    artist: {
+      id: 'parcels',
+      name: 'Parcels',
+      imageUrl:
+        'https://images.unsplash.com/photo-1527333656061-ca7c559ab776?auto=format&fit=crop&w=256&q=80',
+      genres: ['disco', 'electro pop'],
+      popularity: 68,
+    },
+    related: ['jungle', 'daft-punk', 'leisure'],
+    topTracks: [
+      { id: 'overnight', name: 'Overnight', durationMs: 252000, previewUrl, artists: [{ id: 'parcels', name: 'Parcels' }] },
+    ],
+  },
+  'men-i-trust': {
+    artist: {
+      id: 'men-i-trust',
+      name: 'Men I Trust',
+      imageUrl:
+        'https://images.unsplash.com/photo-1464375117522-1311d6a5b81a?auto=format&fit=crop&w=256&q=80',
+      genres: ['dream pop', 'chillwave'],
+      popularity: 75,
+    },
+    related: ['khruangbin', 'menomena', 'jungle'],
+    topTracks: [
+      { id: 'show-me-how', name: 'Show Me How', durationMs: 225000, previewUrl, artists: [{ id: 'men-i-trust', name: 'Men I Trust' }] },
+      { id: 'lauren', name: 'Lauren', durationMs: 219000, previewUrl, artists: [{ id: 'men-i-trust', name: 'Men I Trust' }] },
+    ],
+  },
+  'king-gizzard': {
+    artist: {
+      id: 'king-gizzard',
+      name: 'King Gizzard & The Lizard Wizard',
+      imageUrl:
+        'https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3?auto=format&fit=crop&w=256&q=80',
+      genres: ['psych rock', 'garage rock'],
+      popularity: 78,
+    },
+    related: ['pond', 'unknown-mortal-orchestra', 'tame-impala'],
+    topTracks: [
+      { id: 'rattlesnake', name: 'Rattlesnake', durationMs: 420000, previewUrl, artists: [{ id: 'king-gizzard', name: 'King Gizzard & The Lizard Wizard' }] },
+    ],
+  },
+  'mild-high-club': {
+    artist: {
+      id: 'mild-high-club',
+      name: 'Mild High Club',
+      imageUrl:
+        'https://images.unsplash.com/photo-1435224654926-ecc9f7fa028c?auto=format&fit=crop&w=256&q=80',
+      genres: ['lo-fi psych', 'indie'],
+      popularity: 60,
+    },
+    related: ['unknown-mortal-orchestra', 'khruangbin', 'men-i-trust'],
+    topTracks: [
+      { id: 'homage', name: 'Homage', durationMs: 186000, previewUrl, artists: [{ id: 'mild-high-club', name: 'Mild High Club' }] },
+    ],
+  },
+  'glass-animals': {
+    artist: {
+      id: 'glass-animals',
+      name: 'Glass Animals',
+      imageUrl:
+        'https://images.unsplash.com/photo-1531315630201-bb15abeb1650?auto=format&fit=crop&w=256&q=80',
+      genres: ['alt pop', 'neo-psychedelic'],
+      popularity: 84,
+    },
+    related: ['jungle', 'tame-impala', 'foster-the-people'],
+    topTracks: [
+      { id: 'heat-waves', name: 'Heat Waves', durationMs: 239000, previewUrl, artists: [{ id: 'glass-animals', name: 'Glass Animals' }] },
+    ],
+  },
+};
+
+export function mockSearch(query: string, limit: number) {
+  const normalized = query.trim().toLowerCase();
+  const results = Object.values(ARTISTS)
+    .map((entry) => entry.artist)
+    .filter((artist) => artist.name.toLowerCase().includes(normalized));
+  return Promise.resolve(results.slice(0, limit));
+}
+
+export function mockRelated(id: string) {
+  const entry = ARTISTS[id];
+  if (!entry) return Promise.resolve<Artist[]>([]);
+  const related = entry.related
+    .map((relatedId) => ARTISTS[relatedId]?.artist)
+    .filter(Boolean) as Artist[];
+  return Promise.resolve(related);
+}
+
+export function mockTopTracks(id: string) {
+  const entry = ARTISTS[id];
+  if (!entry) return Promise.resolve<Track[]>([]);
+  return Promise.resolve(entry.topTracks);
+}
+
+export function mockArtist(id: string) {
+  const entry = ARTISTS[id];
+  return entry ? Promise.resolve(entry.artist) : Promise.resolve<Artist | null>(null);
+}
+
+export function mockFavorites(token: string) {
+  if (typeof window === 'undefined') return Promise.resolve([]);
+  const stored = window.localStorage.getItem(`musicdiscovery.favorites.${token}`);
+  if (!stored) return Promise.resolve([]);
+  return Promise.resolve(JSON.parse(stored));
+}
+
+export function mockAddFavorite(token: string, body: { artistId: string; name: string; imageUrl?: string }) {
+  if (typeof window === 'undefined') return Promise.resolve(body);
+  const key = `musicdiscovery.favorites.${token}`;
+  const stored = window.localStorage.getItem(key);
+  const list = stored ? (JSON.parse(stored) as typeof body[]) : [];
+  if (!list.find((item) => item.artistId === body.artistId)) {
+    list.push(body);
+  }
+  window.localStorage.setItem(key, JSON.stringify(list));
+  return Promise.resolve(body);
+}
+
+export function mockSnapshots(token: string) {
+  if (typeof window === 'undefined') return Promise.resolve([]);
+  const key = `musicdiscovery.snapshots.${token}`;
+  const stored = window.localStorage.getItem(key);
+  if (!stored) return Promise.resolve([]);
+  return Promise.resolve(JSON.parse(stored));
+}
+
+export function mockCreateSnapshot(token: string, body: { title: string; graphJson: any; previewUrl?: string }) {
+  if (typeof window === 'undefined') return Promise.resolve(body);
+  const key = `musicdiscovery.snapshots.${token}`;
+  const stored = window.localStorage.getItem(key);
+  const list = stored ? (JSON.parse(stored) as typeof body[]) : [];
+  list.push(body);
+  window.localStorage.setItem(key, JSON.stringify(list));
+  return Promise.resolve(body);
+}
+
+export const mockUser = {
+  token: 'demo-token',
+  user: {
+    id: 'demo-user',
+    provider: 'anonymous',
+    displayName: 'Demo Explorer',
+  },
+};

--- a/app/projects/music-discovery/client/lib/types.ts
+++ b/app/projects/music-discovery/client/lib/types.ts
@@ -1,0 +1,37 @@
+export type Artist = {
+  id: string;
+  name: string;
+  imageUrl?: string;
+  genres?: string[];
+  popularity?: number;
+};
+
+export type Track = {
+  id: string;
+  name: string;
+  previewUrl?: string;
+  durationMs: number;
+  artists: { id: string; name: string }[];
+};
+
+export type NodeData = {
+  id: string;
+  artistId: string;
+  name: string;
+  imageUrl?: string;
+  pinned?: boolean;
+  x?: number;
+  y?: number;
+  fx?: number;
+  fy?: number;
+};
+
+export type EdgeData = { source: string; target: string };
+
+export type GraphState = {
+  nodes: NodeData[];
+  edges: EdgeData[];
+  pivotNodeId: string | null;
+  loadedNeighbors: Record<string, string[]>;
+  selectedNodeId: string | null;
+};

--- a/app/projects/music-discovery/client/store/graphStore.ts
+++ b/app/projects/music-discovery/client/store/graphStore.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { create } from 'zustand';
+import { nanoid } from 'nanoid';
+import type { EdgeData, GraphState, NodeData } from '../lib/types';
+
+type GraphStore = GraphState & {
+  setPivot: (nodeId: string | null) => void;
+  setSelected: (nodeId: string | null) => void;
+  addNeighbors: (pivotId: string, artists: { id: string; name: string; imageUrl?: string }[]) => void;
+  upsertRoot: (artist: { id: string; name: string; imageUrl?: string }) => string;
+  reset: () => void;
+};
+
+function radialPosition(index: number, total: number, cx: number, cy: number, radius: number) {
+  const angle = (index / Math.max(total, 1)) * Math.PI * 2;
+  return {
+    x: cx + Math.cos(angle) * radius,
+    y: cy + Math.sin(angle) * radius,
+  };
+}
+
+export const useGraphStore = create<GraphStore>((set, get) => ({
+  nodes: [],
+  edges: [],
+  pivotNodeId: null,
+  selectedNodeId: null,
+  loadedNeighbors: {},
+
+  setPivot(nodeId) {
+    set({ pivotNodeId: nodeId });
+  },
+
+  setSelected(nodeId) {
+    set({ selectedNodeId: nodeId });
+  },
+
+  upsertRoot(artist) {
+    const state = get();
+    const existing = state.nodes.find((node) => node.artistId === artist.id);
+    if (existing) {
+      set({ pivotNodeId: existing.id, selectedNodeId: existing.id });
+      return existing.id;
+    }
+
+    const id = nanoid();
+    const node: NodeData = {
+      id,
+      artistId: artist.id,
+      name: artist.name,
+      imageUrl: artist.imageUrl,
+      x: 0,
+      y: 0,
+    };
+
+    set({
+      nodes: [node],
+      edges: [],
+      pivotNodeId: id,
+      selectedNodeId: id,
+      loadedNeighbors: {},
+    });
+
+    return id;
+  },
+
+  addNeighbors(pivotId, artists) {
+    const state = get();
+    const pivot = state.nodes.find((node) => node.id === pivotId);
+    if (!pivot) return;
+
+    const existingIds = new Set(state.nodes.map((node) => node.artistId));
+    const newNodes: NodeData[] = [];
+    const newEdges: EdgeData[] = [];
+
+    const filtered = artists.filter((artist) => !existingIds.has(artist.id));
+    const radius = 220;
+
+    filtered.forEach((artist, index) => {
+      const id = nanoid();
+      const position = radialPosition(index, filtered.length, pivot.x ?? 0, pivot.y ?? 0, radius);
+      newNodes.push({
+        id,
+        artistId: artist.id,
+        name: artist.name,
+        imageUrl: artist.imageUrl,
+        ...position,
+      });
+      newEdges.push({ source: pivot.id, target: id });
+    });
+
+    artists.forEach((artist) => {
+      const existing = state.nodes.find((node) => node.artistId === artist.id);
+      if (
+        existing &&
+        !state.edges.some(
+          (edge) =>
+            (edge.source === pivot.id && edge.target === existing.id) ||
+            (edge.target === pivot.id && edge.source === existing.id),
+        )
+      ) {
+        newEdges.push({ source: pivot.id, target: existing.id });
+      }
+    });
+
+    set({
+      nodes: [...state.nodes, ...newNodes],
+      edges: [...state.edges, ...newEdges],
+      loadedNeighbors: {
+        ...state.loadedNeighbors,
+        [pivot.artistId]: artists.map((artist) => artist.id),
+      },
+    });
+  },
+
+  reset() {
+    set({ nodes: [], edges: [], pivotNodeId: null, selectedNodeId: null, loadedNeighbors: {} });
+  },
+}));

--- a/app/projects/music-discovery/client/styles.module.css
+++ b/app/projects/music-discovery/client/styles.module.css
@@ -1,0 +1,349 @@
+.app {
+  --bg: #0b0d12;
+  --panel: #121621;
+  --muted: #9aa4b2;
+  --text: #e6e9ef;
+  --accent: #59a2ff;
+  display: grid;
+  grid-template-rows: 60px 1fr 64px;
+  background: var(--bg);
+  color: var(--text);
+  border-radius: 16px;
+  border: 1px solid rgba(89, 162, 255, 0.1);
+  overflow: hidden;
+  box-shadow: 0 32px 60px rgba(8, 10, 18, 0.45);
+  min-height: 720px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+  border-bottom: 1px solid #1c2230;
+  background: linear-gradient(135deg, rgba(18, 22, 33, 0.95), rgba(12, 16, 26, 0.95));
+  backdrop-filter: blur(16px);
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  font-size: 18px;
+}
+
+.main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  min-height: 0;
+}
+
+.canvasWrap {
+  position: relative;
+  background: radial-gradient(circle at top left, rgba(89, 162, 255, 0.06), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(95, 205, 241, 0.08), transparent 45%);
+}
+
+.side {
+  border-left: 1px solid #1c2230;
+  background: rgba(12, 16, 26, 0.94);
+  backdrop-filter: blur(20px);
+  overflow-y: auto;
+}
+
+.footer {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-top: 1px solid #1c2230;
+  background: rgba(12, 16, 26, 0.94);
+  backdrop-filter: blur(20px);
+}
+
+.search {
+  flex: 1;
+  display: flex;
+  position: relative;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(89, 162, 255, 0.2);
+  background: rgba(8, 12, 21, 0.9);
+  color: var(--text);
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: rgba(89, 162, 255, 0.55);
+  box-shadow: 0 0 0 3px rgba(89, 162, 255, 0.2);
+}
+
+.searchList {
+  position: absolute;
+  top: 52px;
+  left: 0;
+  right: 0;
+  background: rgba(12, 16, 26, 0.98);
+  border: 1px solid rgba(89, 162, 255, 0.15);
+  border-radius: 14px;
+  overflow: hidden;
+  z-index: 40;
+  box-shadow: 0 32px 60px rgba(8, 10, 18, 0.55);
+}
+
+.menu {
+  position: absolute;
+  background: rgba(18, 24, 40, 0.98);
+  border: 1px solid rgba(89, 162, 255, 0.18);
+  border-radius: 16px;
+  min-width: 240px;
+  padding: 12px;
+  box-shadow: 0 40px 70px rgba(8, 10, 18, 0.65);
+  backdrop-filter: blur(18px);
+}
+
+.menuTitle {
+  margin: 4px 6px 10px;
+  font-size: 13px;
+  color: rgba(230, 233, 239, 0.7);
+  letter-spacing: 0.2px;
+}
+
+.menuButton {
+  width: 100%;
+  text-align: left;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease, opacity 0.18s ease;
+  font-size: 14px;
+}
+
+.menuButton:hover:not(:disabled) {
+  background: rgba(89, 162, 255, 0.08);
+  transform: translateX(2px);
+}
+
+.track {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  transition: background 0.2s ease;
+}
+
+.track:hover {
+  background: rgba(89, 162, 255, 0.08);
+}
+
+.track small {
+  color: var(--muted);
+}
+
+.btn {
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(89, 162, 255, 0.35);
+  background: rgba(14, 19, 32, 0.9);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.2px;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(18, 24, 40, 0.95);
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btnPrimary {
+  border-color: rgba(89, 162, 255, 0.65);
+  background: linear-gradient(135deg, rgba(89, 162, 255, 0.28), rgba(95, 205, 241, 0.35));
+}
+
+.label {
+  color: rgba(230, 233, 239, 0.65);
+  font-size: 12px;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.dialogBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 9, 15, 0.75);
+  display: grid;
+  place-items: center;
+  z-index: 100;
+  backdrop-filter: blur(6px);
+}
+
+.dialog {
+  background: rgba(12, 16, 26, 0.96);
+  border: 1px solid rgba(89, 162, 255, 0.2);
+  border-radius: 16px;
+  padding: 20px;
+  width: min(420px, 90vw);
+  box-shadow: 0 40px 80px rgba(8, 10, 18, 0.7);
+}
+
+.dialogTitle {
+  margin: 0 0 12px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.dialogInput {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(89, 162, 255, 0.25);
+  background: rgba(8, 12, 21, 0.9);
+  color: var(--text);
+  font-size: 14px;
+}
+
+.dialogActions {
+  margin-top: 18px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.sideSection {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sideSectionHeader {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(230, 233, 239, 0.7);
+  letter-spacing: 0.25px;
+}
+
+.snapshotList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.snapshotCard {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(89, 162, 255, 0.15);
+  background: rgba(14, 19, 32, 0.8);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.snapshotTitle {
+  font-weight: 600;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  background: rgba(89, 162, 255, 0.12);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  letter-spacing: 0.4px;
+  color: rgba(230, 233, 239, 0.75);
+}
+
+.footerPlayer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.range {
+  width: 100%;
+}
+
+.tabs {
+  display: inline-flex;
+  border-radius: 999px;
+  border: 1px solid rgba(89, 162, 255, 0.2);
+  background: rgba(12, 16, 26, 0.75);
+  padding: 4px;
+  gap: 4px;
+}
+
+.tabButton {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  background: transparent;
+  color: rgba(230, 233, 239, 0.7);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tabButtonActive {
+  background: linear-gradient(135deg, rgba(89, 162, 255, 0.4), rgba(95, 205, 241, 0.35));
+  color: white;
+}
+
+.blueprint {
+  background: white;
+  color: #0b0d12;
+  border-radius: 16px;
+  border: 1px solid rgba(12, 16, 26, 0.1);
+  padding: 24px;
+}
+
+.blueprint :global(h1) {
+  font-size: 32px;
+}
+
+.blueprint :global(h2) {
+  margin-top: 24px;
+  font-size: 24px;
+}
+
+.blueprint :global(h3) {
+  margin-top: 18px;
+  font-size: 18px;
+}
+
+.blueprint :global(code) {
+  background: rgba(12, 16, 26, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.blueprint :global(pre) {
+  background: rgba(12, 16, 26, 0.85);
+  color: white;
+  padding: 16px;
+  border-radius: 12px;
+  overflow-x: auto;
+}

--- a/app/projects/music-discovery/page.tsx
+++ b/app/projects/music-discovery/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
-import ReactMarkdown from "react-markdown";
 import ProjectVersionBanner from "../components/ProjectVersionBanner";
+import MusicDiscoveryExperience from "./client/MusicDiscoveryExperience";
 
 export const metadata = {
   title: "MusicDiscovery Blueprint",
@@ -18,18 +18,17 @@ export default async function MusicDiscoveryProjectPage() {
   const blueprint = await fs.readFile(blueprintPath, "utf8");
   
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <ProjectVersionBanner className="mx-auto mt-4 max-w-3xl" />
-      <header className="space-y-2 rounded-lg border bg-white p-6 shadow-sm">
-        <h1 className="text-2xl font-semibold text-gray-900">MusicDiscovery</h1>
-        <p className="text-sm text-gray-600">
-          Een end-to-end blueprint voor een interactieve muziekontdekkingsapp met Spotify-integratie,
-          force-directed graaf en gedeelde snapshots.
+      <header className="space-y-3 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-semibold text-gray-900">MusicDiscovery</h1>
+        <p className="text-base text-gray-600">
+          Ontdek nieuwe artiesten via een interactieve graaf, beluister 30-seconden previews en bewaar snapshots van je
+          ontdekkingstocht. De blueprint blijft beschikbaar als referentie maar de app hieronder is volledig interactief en
+          draait op mockdata wanneer er geen backend aanwezig is.
         </p>
       </header>
-      <article className="prose prose-slate max-w-none rounded-lg border bg-white p-6 shadow-sm">
-        <ReactMarkdown>{blueprint}</ReactMarkdown>
-      </article>
+      <MusicDiscoveryExperience blueprint={blueprint} />
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,20 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-query": "^5.51.1",
         "@tensorflow-models/face-landmarks-detection": "^1.0.6",
         "@tensorflow/tfjs-backend-webgl": "^4.22.0",
         "@tensorflow/tfjs-converter": "^4.22.0",
         "@tensorflow/tfjs-core": "^4.22.0",
+        "axios": "^1.7.2",
         "gsap": "^3.13.0",
+        "nanoid": "^5.0.7",
         "next": "14.2.31",
         "react": "^18",
         "react-dom": "^18",
-        "react-markdown": "^10.1.0"
+        "react-force-graph-2d": "^1.25.4",
+        "react-markdown": "^10.1.0",
+        "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -552,6 +557,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tensorflow-models/face-detection": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tensorflow-models/face-detection/-/face-detection-1.0.3.tgz",
@@ -657,6 +688,12 @@
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1327,6 +1364,15 @@
       "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1610,6 +1656,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1634,6 +1686,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1661,6 +1724,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1730,7 +1803,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1795,6 +1867,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -1923,6 +2007,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1979,6 +2075,222 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2114,6 +2426,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2165,7 +2486,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2261,7 +2581,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2271,7 +2590,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2309,7 +2627,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2322,7 +2639,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2964,6 +3280,40 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2980,6 +3330,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/force-graph": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.0.tgz",
+      "integrity": "sha512-aTnihCmiMA0ItLJLCbrQYS9mzriopW24goFPgUnKAAmAlPogTSmFWqoBPMXzIfPb7bs04Hur5zEI4WYgLW3Sig==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2994,6 +3370,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3060,7 +3452,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3085,7 +3476,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3221,7 +3611,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3305,7 +3694,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3318,7 +3706,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3429,6 +3816,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3465,6 +3861,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -4000,6 +4405,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -4076,6 +4490,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keyv": {
@@ -4156,6 +4582,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4201,7 +4633,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4824,6 +5255,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4873,9 +5325,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
       "funding": [
         {
           "type": "github",
@@ -4884,10 +5336,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/napi-postinstall": {
@@ -4961,6 +5413,24 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -5470,6 +5940,34 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5484,7 +5982,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5501,6 +5998,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5557,12 +6060,43 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.0.tgz",
+      "integrity": "sha512-Xv5IIk+hsZmB3F2ibja/t6j/b0/1T9dtFOQacTUoLpgzRHrO6wPu1GtQ2LfRqI/imgtaapnXUgQaE8g8enPo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6516,6 +7050,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -6913,6 +7453,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7200,6 +7749,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -11,15 +11,20 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-query": "^5.51.1",
     "@tensorflow-models/face-landmarks-detection": "^1.0.6",
     "@tensorflow/tfjs-backend-webgl": "^4.22.0",
     "@tensorflow/tfjs-converter": "^4.22.0",
     "@tensorflow/tfjs-core": "^4.22.0",
     "gsap": "^3.13.0",
     "next": "14.2.31",
+    "nanoid": "^5.0.7",
+    "axios": "^1.7.2",
     "react": "^18",
     "react-dom": "^18",
-    "react-markdown": "^10.1.0"
+    "react-force-graph-2d": "^1.25.4",
+    "react-markdown": "^10.1.0",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- replace the static blueprint view with an interactive MusicDiscovery app experience
- implement client-side graph, search, favorites, snapshots, and audio preview functionality using mock fallbacks
- add supporting state management, API utilities, styling, and dependencies for the new UI

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd93bf5bc4833389593c892d552899