### PR TITLE
Polish MusicDiscovery API selector

### DIFF
--- a/app/projects/music-discovery/client/MusicDiscoveryExperience.tsx
+++ b/app/projects/music-discovery/client/MusicDiscoveryExperience.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import ReactMarkdown from 'react-markdown';
 import SearchBar from './components/SearchBar';
 import GraphCanvas from './components/GraphCanvas';
 import GlobalPlayer from './components/GlobalPlayer';
@@ -10,37 +9,128 @@ import SidePanel from './components/SidePanel';
 import { AuthProvider } from './lib/auth';
 import styles from './styles.module.css';
 
-const tabs = [
-  { id: 'app', label: 'Interactieve app' },
-  { id: 'blueprint', label: 'Blueprint' },
+const apis = [
+  {
+    id: 'musicbrainz',
+    name: 'MusicBrainz API',
+    description: 'Open muziekencyclopedie zonder authenticatie, ideaal voor metadata en artiestrelaties.',
+    requiresToken: false,
+    docsUrl:
+      'https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2',
+  },
+  {
+    id: 'itunes',
+    name: 'iTunes Search API',
+    description:
+      'Publieke catalogus van Apple Music/iTunes zonder token, perfect voor snelle zoekopdrachten.',
+    requiresToken: false,
+    docsUrl:
+      'https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI',
+  },
+  {
+    id: 'songsterr',
+    name: 'Songsterr Tabs API',
+    description:
+      'Gitaar-tabs, akkoorden en artiestinformatie zonder API-sleutel, ideaal voor creatieve inspiratie.',
+    requiresToken: false,
+    docsUrl: 'https://www.songsterr.com/a/wa/api',
+  },
+  {
+    id: 'spotify',
+    name: 'Spotify Web API',
+    description:
+      'Volledige catalogus met streaming metadata, vereist OAuth-token voor toegang.',
+    requiresToken: true,
+    docsUrl: 'https://developer.spotify.com/documentation/web-api',
+  },
+  {
+    id: 'lastfm',
+    name: 'Last.fm API',
+    description:
+      'Community-statistieken, scrobbles en aanbevelingen via een eenvoudige REST API (API-key vereist).',
+    requiresToken: true,
+    docsUrl: 'https://www.last.fm/api',
+  },
 ] as const;
-
-type Tab = (typeof tabs)[number]['id'];
 
 type Props = { blueprint: string };
 
-function ExperienceShell({ blueprint }: Props) {
-  const [tab, setTab] = useState<Tab>('app');
+function ExperienceShell({ blueprint: _blueprint }: Props) {
+  const [selectedApiId, setSelectedApiId] = useState<string | null>(null);
+  const selectedApi = useMemo(() => apis.find((api) => api.id === selectedApiId) ?? null, [selectedApiId]);
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-slate-100">MusicDiscovery Experience</h2>
-        <div className={styles.tabs}>
-          {tabs.map((item) => (
-            <button
-              key={item.id}
-              className={`${styles.tabButton} ${tab === item.id ? styles.tabButtonActive : ''}`}
-              onClick={() => setTab(item.id)}
-              type="button"
-            >
-              {item.label}
-            </button>
-          ))}
+      <div className={styles.toolbar}>
+        <div>
+          <h2 className="text-xl font-semibold text-slate-100">MusicDiscovery</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Kies een muziek API om te starten. Beschikbaar zijn zowel open bronnen zonder token als platform-API&apos;s met
+            OAuth.
+          </p>
+        </div>
+        <div className={styles.apiPicker}>
+          <span className={styles.apiPickerLabel}>Selecteer muziek API</span>
+          <ul className={styles.apiList} role="list">
+            {apis.map((api) => {
+              const isActive = selectedApiId === api.id;
+
+              return (
+                <li key={api.id}>
+                  <button
+                    className={`${styles.apiButton} ${isActive ? styles.apiButtonActive : ''}`}
+                    onClick={() => setSelectedApiId(api.id)}
+                    type="button"
+                    aria-pressed={isActive}
+                  >
+                    <div className={styles.apiButtonHeader}>
+                      <span>{api.name}</span>
+                      {!api.requiresToken ? (
+                        <span
+                          className={styles.apiBadge}
+                          aria-label="Geen token of key nodig"
+                          title="Geen token of key nodig"
+                        >
+                          🔓
+                        </span>
+                      ) : (
+                        <span
+                          className={styles.apiBadgeLocked}
+                          aria-label="Token of API-sleutel vereist"
+                          title="Token of API-sleutel vereist"
+                        >
+                          🔐
+                        </span>
+                      )}
+                    </div>
+                    <p className={styles.apiDescription}>{api.description}</p>
+                    <span className={styles.apiDocs} aria-hidden="true">
+                      Documentatie · {new URL(api.docsUrl).hostname}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       </div>
 
-      {tab === 'app' ? (
+      <div>
+        {selectedApi ? (
+          <div className={styles.selectionNotice}>
+            <span>
+              Geselecteerde API: <strong>{selectedApi.name}</strong>
+            </span>
+            <a className={styles.selectionLink} href={selectedApi.docsUrl} target="_blank" rel="noreferrer">
+              Bekijk documentatie
+            </a>
+          </div>
+        ) : (
+          <div className={styles.selectionNoticeMuted}>Selecteer een API hierboven om de ervaring te starten.</div>
+        )}
+      </div>
+
+      {selectedApi ? (
         <div className={styles.app}>
           <header className={styles.header}>
             <div className={styles.logo}>MusicDiscovery</div>
@@ -65,11 +155,7 @@ function ExperienceShell({ blueprint }: Props) {
             <GlobalPlayer />
           </footer>
         </div>
-      ) : (
-        <article className={styles.blueprint}>
-          <ReactMarkdown>{blueprint}</ReactMarkdown>
-        </article>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/app/projects/music-discovery/client/styles.module.css
+++ b/app/projects/music-discovery/client/styles.module.css
@@ -185,6 +185,147 @@
   text-transform: uppercase;
 }
 
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .toolbar {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 32px;
+  }
+}
+
+.apiPicker {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 540px;
+}
+
+.apiPickerLabel {
+  font-size: 12px;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  color: rgba(230, 233, 239, 0.6);
+}
+
+.apiList {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.apiButton {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(89, 162, 255, 0.15);
+  background: rgba(12, 16, 26, 0.72);
+  color: #e6e9ef;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  min-height: 108px;
+}
+
+.apiButton:hover {
+  border-color: rgba(89, 162, 255, 0.4);
+  background: rgba(16, 22, 36, 0.88);
+  transform: translateY(-1px);
+}
+
+.apiButtonActive {
+  border-color: rgba(89, 162, 255, 0.75);
+  background: linear-gradient(135deg, rgba(89, 162, 255, 0.22), rgba(95, 205, 241, 0.28));
+  box-shadow: 0 18px 30px rgba(8, 10, 18, 0.38);
+}
+
+.apiButtonHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.apiBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(89, 162, 255, 0.18);
+  font-size: 12px;
+}
+
+.apiBadgeLocked {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(255, 151, 72, 0.2);
+  color: rgba(255, 151, 72, 0.9);
+  font-size: 12px;
+}
+
+.apiDescription {
+  font-size: 12px;
+  color: rgba(230, 233, 239, 0.7);
+}
+
+.apiDocs {
+  margin-top: auto;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: rgba(89, 162, 255, 0.8);
+}
+
+.selectionNotice {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(89, 162, 255, 0.25);
+  background: rgba(12, 16, 26, 0.8);
+  color: #e6e9ef;
+}
+
+.selectionLink {
+  color: rgba(95, 205, 241, 0.95);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.selectionLink:hover {
+  text-decoration: underline;
+}
+
+.selectionNoticeMuted {
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px dashed rgba(89, 162, 255, 0.25);
+  background: rgba(12, 16, 26, 0.6);
+  color: rgba(230, 233, 239, 0.7);
+  font-size: 13px;
+}
+
 .dialogBackdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- reorder the MusicDiscovery API catalogue to prioritise token-free services and add Songsterr as an extra open option
- convert the API picker into an accessible list with pressed-state buttons and badges for both open and locked providers
- refine the picker styling to support the new list layout and locked-state badge treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9bc40d1c833383b99889f442ac0a