### PR TITLE
Lock MusicDiscovery to Deezer + iTunes only (remove Spotify mode)

### DIFF
--- a/MusicDiscovery/README.md
+++ b/MusicDiscovery/README.md
@@ -9,7 +9,13 @@ This folder is reserved for the **MusicDiscovery** webapp that will be published
 - Work in progress: the portfolio tile already links to the app path.
 - The GitHub Pages deploy workflow is prepared to build and publish this app once the source is placed here.
 
+## Data sources
+
+This project intentionally uses only public endpoints:
+
+- Deezer (primary) for related artists and top tracks.
+- iTunes Search API for discovery links and previews.
+
 ## Security
 
 Do **not** commit any `.env` files or secrets in this repository.
-

--- a/MusicDiscovery/apps/api/src/providerRegistry.ts
+++ b/MusicDiscovery/apps/api/src/providerRegistry.ts
@@ -15,7 +15,9 @@ class InvalidProviderError extends HttpError {
 
 const providers = new Map<ProviderId, MusicProvider>();
 
-const ENABLED_PROVIDER_IDS: ProviderId[] = env.SPOTIFY_ENABLED ? ['tokenless', 'itunes', 'spotify'] : ['tokenless', 'itunes'];
+// GitHub Pages deployment: public endpoints only.
+// Tokenless = Deezer-first (no OAuth), plus iTunes links.
+const ENABLED_PROVIDER_IDS: ProviderId[] = ['tokenless', 'itunes'];
 const ENABLED_PROVIDER_SET = new Set<ProviderId>(ENABLED_PROVIDER_IDS);
 
 function parseMode(value: unknown): ProviderId | null {

--- a/MusicDiscovery/apps/web/src/hooks/useProviderSelection.ts
+++ b/MusicDiscovery/apps/web/src/hooks/useProviderSelection.ts
@@ -11,9 +11,9 @@ interface ProviderSelectionState {
   selectProvider: (next: ProviderId) => void;
 }
 
-// Locked provider selection: always use Deezer (primary) with iTunes links available.
+// Locked provider selection: always use Deezer-first tokenless mode with iTunes links available.
 // This intentionally disables runtime switching and removes any persisted selection.
-const LOCKED_PROVIDER: ProviderId = 'deezer';
+const LOCKED_PROVIDER: ProviderId = 'tokenless';
 
 export function useProviderSelection(): ProviderSelectionState {
   const selectProvider = useCallback(() => {
@@ -22,7 +22,7 @@ export function useProviderSelection(): ProviderSelectionState {
 
   return {
     provider: LOCKED_PROVIDER,
-    providers: PROVIDERS.filter((p) => p.id === 'deezer' || p.id === 'itunes'),
+    providers: PROVIDERS.filter((p) => p.id === 'tokenless' || p.id === 'itunes'),
     status: 'ready',
     error: null,
     selectProvider

--- a/MusicDiscovery/apps/web/src/providerSelection.ts
+++ b/MusicDiscovery/apps/web/src/providerSelection.ts
@@ -1,8 +1,8 @@
 import type { ProviderId } from '@musicdiscovery/shared';
 
 // Provider selection has been removed for GitHub Pages deployment.
-// The app is intentionally locked to Deezer (primary) with iTunes links available.
-const LOCKED_PROVIDER: ProviderId = 'deezer';
+// The app is intentionally locked to Deezer-first "tokenless" mode with iTunes links available.
+const LOCKED_PROVIDER: ProviderId = 'tokenless';
 
 export function syncProviderSelection(_available: ProviderId[], _defaultProvider: ProviderId): ProviderId {
   return LOCKED_PROVIDER;
@@ -17,5 +17,5 @@ export function setSelectedProvider(_id: ProviderId) {
 }
 
 export function isSelectableProvider(value: unknown): value is ProviderId {
-  return value === 'deezer' || value === 'itunes';
+  return value === 'tokenless' || value === 'itunes';
 }

--- a/MusicDiscovery/packages/providers/src/factory.ts
+++ b/MusicDiscovery/packages/providers/src/factory.ts
@@ -1,6 +1,5 @@
 import type { ProviderId } from '@musicdiscovery/shared';
 import { TokenlessProvider } from './tokenless/index.js';
-import { SpotifyProvider } from './spotify/index.js';
 import { ItunesProvider } from './itunes/index.js';
 import type { MusicProvider } from './types.js';
 import type { HttpRequestOptions } from './httpClient.js';
@@ -10,7 +9,7 @@ export interface ProviderFactoryOptions {
 }
 
 const PROVIDER_FACTORIES: Record<ProviderId, (options?: ProviderFactoryOptions) => MusicProvider> = {
-  spotify: () => new SpotifyProvider(),
+  // "tokenless" is our Deezer-first implementation (no OAuth / no secrets).
   tokenless: (options) => new TokenlessProvider({ http: options?.http }),
   itunes: () => new ItunesProvider()
 };

--- a/MusicDiscovery/packages/shared/src/providers.ts
+++ b/MusicDiscovery/packages/shared/src/providers.ts
@@ -1,4 +1,4 @@
-export const PROVIDER_MODES = ['tokenless', 'spotify', 'itunes'] as const;
+export const PROVIDER_MODES = ['tokenless', 'itunes'] as const;
 export type ProviderId = (typeof PROVIDER_MODES)[number];
 
 export interface ProviderMetadata {
@@ -12,16 +12,9 @@ export interface ProviderMetadata {
 export const PROVIDERS: ProviderMetadata[] = [
   {
     id: 'tokenless',
-    label: 'Tokenless (Deezer + iTunes)',
+    label: 'Deezer',
     description:
-      'Uses Deezer for related artists and top tracks while falling back to the iTunes Search API for discovery.',
-    supportsRelated: true,
-    supportsTopTracks: true
-  },
-  {
-    id: 'spotify',
-    label: 'Spotify',
-    description: 'Full Spotify catalogue via the Client Credentials flow (requires credentials).',
+      'Uses Deezer for related artists and top tracks while falling back to the iTunes Search API for discovery and previews.',
     supportsRelated: true,
     supportsTopTracks: true
   },


### PR DESCRIPTION
Spotify is uit de gedeelde provider-types/metadata gehaald, zodat ProviderId enkel nog tokenless (Deezer-first) en itunes bevat

De provider factory maakt nu alleen nog tokenless en itunes aan (Spotify mapping/imports verwijderd)

De API registry accepteert enkel nog tokenless en itunes (geen SPOTIFY_ENABLED/spotify branches meer)​

De webapp blijft “locked” (geen UI/keuze voor user), maar is terug consistent met tokenless als default