### PR TITLE
Fix Render build: pino-http callable import + remove unused p-limit type

### DIFF
--- a/MusicDiscovery/apps/api/src/logger.ts
+++ b/MusicDiscovery/apps/api/src/logger.ts
@@ -2,10 +2,20 @@
 export { logger, createChildLogger } from './config/logger.js';
 
 import { randomUUID } from 'node:crypto';
-import pinoHttp from 'pino-http';
 import type { Request, Response } from 'express';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { logger } from './config/logger.js';
+
+// pino-http v11's ESM/CJS interop can cause the default import to not be callable
+// under some TS/NodeNext setups. Import as namespace and select the callable export.
+import * as pinoHttpImport from 'pino-http';
+
+const pinoHttp =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ((pinoHttpImport as any).default ?? pinoHttpImport) as unknown as (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    opts: any
+  ) => any;
 
 export function createRequestLogger() {
   return pinoHttp({

--- a/MusicDiscovery/packages/providers/src/tokenless/index.ts
+++ b/MusicDiscovery/packages/providers/src/tokenless/index.ts
@@ -1,4 +1,3 @@
-import type pLimit from 'p-limit';
 import pLimitLib from 'p-limit';
 
 import type { Artist, MusicProvider, Track } from '../types.js';
@@ -287,7 +286,7 @@ export class TokenlessProvider implements MusicProvider {
             `${ITUNES_SEARCH_URL}?term=${encodeURIComponent(genre)}&entity=musicArtist&limit=${Math.max(limit * 3, 25)}`
           );
           return data.results;
-        } catch (error) {
+        } catch {
           return [];
         }
       })


### PR DESCRIPTION
Fixes Render build failing on main due to:

1) `pino-http` v11 ESM/CJS interop causing `import pinoHttp from 'pino-http'` to not be callable under NodeNext on Render.
   - Switched to namespace import and selected callable export (`default ?? module`).

2) `noUnusedLocals` error in providers tokenless due to unused `import type pLimit`.
   - Removed unused type import.

This should unblock `pnpm --filter @musicdiscovery/api build` on Render.