### PR TITLE
Connect MusicDiscovery web app to Render API

### DIFF
--- a/MusicDiscovery/apps/web/.env.production
+++ b/MusicDiscovery/apps/web/.env.production
@@ -1,0 +1,2 @@
+# Production API endpoint (Render)
+VITE_API_PREFIX=https://harounminhas-github-io.onrender.com/api


### PR DESCRIPTION
## Changes

Adds `.env.production` to configure the web app to call the Render API in production.

### Before
```typescript
const apiPrefix = '/api';  // Relative path
```
→ Web app on GitHub Pages tried to call `https://harounminhas.github.io/api` (doesn't exist)

### After
```env
VITE_API_PREFIX=https://harounminhas-github-io.onrender.com/api
```
→ Web app on GitHub Pages calls `https://harounminhas-github-io.onrender.com/api` ✅

## Environments

### Development (localhost)
- Uses vite proxy → `http://localhost:8080/api`
- No change

### Production (GitHub Pages)
- Calls Render directly → `https://harounminhas-github-io.onrender.com/api`
- **New behavior**

## CORS Note

Zorg dat je Render API CORS headers heeft voor `https://harounminhas.github.io`. Als dat nog niet zo is, moet je dit toevoegen aan de API config.