### PR TITLE
Add GitHub Pages to API CORS whitelist

### DIFF
--- a/MusicDiscovery/apps/api/src/index.ts
+++ b/MusicDiscovery/apps/api/src/index.ts
@@ -12,7 +12,12 @@ const app = express();
 // Security and parsing middleware
 app.use(helmet());
 app.use(express.json());
-app.use(cors({ origin: env.CORS_ORIGIN as string, credentials: true }));
+app.use(
+  cors({
+    origin: env.CORS_ORIGIN,
+    credentials: true
+  })
+);
 
 // Logging middleware
 app.use(createRequestLogger());
@@ -22,8 +27,8 @@ app.use(apiRateLimiter);
 
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
-  res.json({ 
-    status: 'ok', 
+  res.json({
+    status: 'ok',
     mode: env.DATA_MODE,
     timestamp: new Date().toISOString(),
     environment: env.NODE_ENV
@@ -39,11 +44,12 @@ app.use(errorHandler);
 // Start server
 const server = app.listen(env.PORT, () => {
   logger.info(
-    { 
-      port: env.PORT, 
+    {
+      port: env.PORT,
       mode: env.DATA_MODE,
-      environment: env.NODE_ENV
-    }, 
+      environment: env.NODE_ENV,
+      corsOrigins: env.CORS_ORIGIN
+    },
     'MusicDiscovery API server started'
   );
 });

--- a/MusicDiscovery/apps/api/src/types/env.ts
+++ b/MusicDiscovery/apps/api/src/types/env.ts
@@ -5,7 +5,14 @@ export const EnvSchema = z.object({
   MARKET: z.string().default('BE'),
   PORT: z.coerce.number().default(8080),
   NODE_ENV: z.string().default('development'),
-  CORS_ORIGIN: z.string().default('*'),
+  CORS_ORIGIN: z
+    .string()
+    .default('http://localhost:5173,http://localhost:4173,https://harounminhas.github.io')
+    .transform((val) => {
+      // Support comma-separated list of origins
+      if (val === '*') return '*';
+      return val.split(',').map((origin) => origin.trim());
+    }),
   LOG_LEVEL: z
     .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
     .default('info'),


### PR DESCRIPTION
## Changes

Configures CORS to allow requests from GitHub Pages.

### CORS Origins

**Default (no env var set)**:
```
http://localhost:5173      ← dev server
http://localhost:4173      ← preview
https://harounminhas.github.io  ← production
```

**Override via env var** (Render dashboard):
```bash
CORS_ORIGIN=https://harounminhas.github.io,https://custom-domain.com
```

**Allow all** (niet aanbevolen voor productie):
```bash
CORS_ORIGIN=*
```

### Implementation

1. `CORS_ORIGIN` now supports comma-separated list
2. Default includes localhost + GitHub Pages
3. Zod schema transforms string → array for `cors()` middleware
4. Logs `corsOrigins` at startup for debugging

### Testing

Na deploy kan je testen:
```bash
curl -I -X OPTIONS \
  -H "Origin: https://harounminhas.github.io" \
  -H "Access-Control-Request-Method: GET" \
  https://harounminhas-github-io.onrender.com/api/health
```

Zou moeten retourneren:
```
Access-Control-Allow-Origin: https://harounminhas.github.io
Access-Control-Allow-Credentials: true
```