### PR TITLE
Fix MusicDiscovery monorepo build in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,16 +44,27 @@ jobs:
         working-directory: ./phase10
         run: npm run build
 
-      # Build MusicDiscovery (Option C: source lives INSIDE this repo under ./MusicDiscovery)
+      # Build MusicDiscovery monorepo
       - name: Build MusicDiscovery (if present)
         run: |
           if [ -d "MusicDiscovery" ]; then
             echo "MusicDiscovery folder found - building..."
             cd MusicDiscovery
+            
+            # Enable pnpm
             corepack enable
+            
+            # Install all workspace dependencies
             pnpm install --frozen-lockfile
-            pnpm --filter @musicdiscovery/web exec tsc -p tsconfig.json
-            pnpm --filter @musicdiscovery/web exec vite build --base=/MusicDiscovery/
+            
+            # Build shared package first (dependency)
+            echo "Building @musicdiscovery/shared..."
+            pnpm --filter @musicdiscovery/shared run build
+            
+            # Build web app (depends on shared)
+            echo "Building @musicdiscovery/web..."
+            pnpm --filter @musicdiscovery/web run build --base=/MusicDiscovery/
+            
             cd ..
           else
             echo "MusicDiscovery folder not found - skipping build."


### PR DESCRIPTION
## Problem

GitHub Actions build failing met:
```
Cannot find module '@musicdiscovery/shared' or its corresponding type declarations.
```

### Root Cause

De CI workflow probeerde `@musicdiscovery/web` te builden zonder eerst `@musicdiscovery/shared` te builden. In een pnpm workspace moet je dependencies in de juiste volgorde builden.

## Solution

### Build Order Fix

**Before**:
```bash
pnpm --filter @musicdiscovery/web exec tsc -p tsconfig.json
pnpm --filter @musicdiscovery/web exec vite build
```
❌ Shared package not built → TypeScript errors

**After**:
```bash
# 1. Build shared package first
pnpm --filter @musicdiscovery/shared run build

# 2. Build web app (can now import shared)
pnpm --filter @musicdiscovery/web run build --base=/MusicDiscovery/
```
✅ Dependencies built in correct order

## Changes

1. **Build `@musicdiscovery/shared` first**: Runs `tsup` to compile TypeScript → `dist/index.js` + type definitions
2. **Then build `@musicdiscovery/web`**: Can now resolve `import ... from '@musicdiscovery/shared'`
3. **Use `pnpm run build`**: Instead of manually running `tsc` + `vite`, use the package's build script

## Verification

Na merge zou de build moeten slagen:
- ✅ `@musicdiscovery/shared` builds naar `packages/shared/dist/`
- ✅ `@musicdiscovery/web` kan shared importeren
- ✅ Vite build output → `apps/web/dist/`
- ✅ Deploy naar GitHub Pages op `/MusicDiscovery/`