### PR TITLE
Add language dropdown on homepage (NL/EN)

### DIFF
--- a/src/components/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Dropdown } from 'react-bootstrap';
+
+const LANG_STORAGE_KEY = 'lang';
+
+const normalizeLang = (value) => {
+  if (value === 'en' || value === 'nl') return value;
+  return 'nl';
+};
+
+const LanguageSwitcher = () => {
+  const initialLang = useMemo(() => {
+    try {
+      return normalizeLang(localStorage.getItem(LANG_STORAGE_KEY));
+    } catch {
+      return 'nl';
+    }
+  }, []);
+
+  const [lang, setLang] = useState(initialLang);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LANG_STORAGE_KEY, lang);
+    } catch {
+      // ignore
+    }
+  }, [lang]);
+
+  const currentFlag = lang === 'nl' ? '🇧🇪' : '🇬🇧';
+
+  return (
+    <Dropdown align="end">
+      <Dropdown.Toggle
+        id="language-switcher"
+        variant="link"
+        size="sm"
+        className="p-0 text-decoration-none"
+        aria-label="Kies taal"
+      >
+        <span aria-hidden="true" style={{ fontSize: '1.1rem' }}>
+          {currentFlag}
+        </span>
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu>
+        <Dropdown.Item
+          active={lang === 'nl'}
+          onClick={() => setLang('nl')}
+          aria-current={lang === 'nl' ? 'true' : undefined}
+        >
+          🇧🇪 NL{lang === 'nl' ? ' ✓' : ''}
+        </Dropdown.Item>
+        <Dropdown.Item
+          active={lang === 'en'}
+          onClick={() => setLang('en')}
+          aria-current={lang === 'en' ? 'true' : undefined}
+        >
+          🇬🇧 EN{lang === 'en' ? ' ✓' : ''}
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Container, Row, Col, Card, Button } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import LanguageSwitcher from '../components/LanguageSwitcher';
 
 /**
  * Renders the main landing page for the speech therapy practice.
@@ -11,6 +12,10 @@ const HomePage = () => {
     <div>
       <section className="hero-section">
         <Container>
+          <div className="d-flex justify-content-end pt-2">
+            <LanguageSwitcher />
+          </div>
+
           <Row className="align-items-center g-4">
             <Col lg={7} className="text-center text-lg-start">
               <h1 className="display-5 fw-bold text-uppercase text-wrap">Logopedie voor volwassenen en kinderen in Brussel</h1>


### PR DESCRIPTION
Implementeert een subtiele taalkeuze dropdown op de mainpage.

- Nieuwe component: `src/components/LanguageSwitcher.js`
- HomePage toont rechtsboven een klein vlag-icoon (🇧🇪/🇬🇧) dat een mini-menu opent met NL/EN.
- Gekozen taal wordt opgeslagen in `localStorage` (`lang`) zodat andere pagina’s later dezelfde keuze kunnen volgen.

Checklist:
- [x] Menu sluit automatisch bij klik buiten het menu
- [x] Geselecteerde optie wordt aangeduid