### PR TITLE
Remove emojis from UI/i18n and replace with neutral symbol icons

### DIFF
--- a/colorhunt/index.html
+++ b/colorhunt/index.html
@@ -18,7 +18,7 @@
     <!-- Color Palette Widget (Floating) -->
     <div id="colorWidget" class="color-widget">
         <button id="widgetToggle" class="widget-toggle" data-i18n-aria="widget.toggleAria">
-            🎨
+            ◈
         </button>
         <div id="widgetContent" class="widget-content">
             <div class="widget-header">
@@ -86,17 +86,17 @@
                     <li class="nav-item"><a class="nav-link" href="#utilities" data-i18n="nav.utilities">Utilities</a></li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="langDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n-aria="lang.aria">
-                            <span id="langCurrent">🇧🇪 NL</span>
+                            <span id="langCurrent">NL</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="langDropdown">
                             <li>
                                 <button class="dropdown-item" type="button" data-lang="nl">
-                                    🇧🇪 <span data-i18n="lang.nl">Nederlands</span> <span class="lang-check" data-check-lang="nl" aria-hidden="true">✓</span>
+                                    NL <span data-i18n="lang.nl">Nederlands</span> <span class="lang-check" data-check-lang="nl" aria-hidden="true">✓</span>
                                 </button>
                             </li>
                             <li>
                                 <button class="dropdown-item" type="button" data-lang="en">
-                                    🇬🇧 <span data-i18n="lang.en">Engels</span> <span class="lang-check" data-check-lang="en" aria-hidden="true">✓</span>
+                                    EN <span data-i18n="lang.en">Engels</span> <span class="lang-check" data-check-lang="en" aria-hidden="true">✓</span>
                                 </button>
                             </li>
                         </ul>
@@ -111,7 +111,7 @@
         <div class="container">
             <h1 class="display-3 fw-bold">ColorHunt Palette Tester</h1>
             <p class="lead" data-i18n="hero.lead">Test Bootstrap componenten met ColorHunt color palettes</p>
-            <p class="mt-3" data-i18n="hero.cta">Klik op 🎨 net onder de menubalk (rechtsboven) om palettes te importeren en toe te passen</p>
+            <p class="mt-3" data-i18n="hero.cta">Klik op ◈ net onder de menubalk (rechtsboven) om palettes te importeren en toe te passen</p>
         </div>
     </div>
 

--- a/colorhunt/script.js
+++ b/colorhunt/script.js
@@ -17,8 +17,8 @@ const TRANSLATIONS = {
 
         'hero.lead': 'Test Bootstrap componenten met ColorHunt color palettes',
         'hero.cta': 'Gebruik de widget net onder de menubalk (rechtsboven) om palettes te importeren en toe te passen.',
-        'hero.helperNl': '🇧🇪 Gebruik de 🎨-widget om kleurenpaletten direct uit ColorHunt te testen op alle componenten hieronder.',
-        'hero.helperEn': '🇬🇧 Use the 🎨 widget to test ColorHunt palettes instantly across all components below.',
+        'hero.helperNl': 'NL Gebruik de ◈-widget om kleurenpaletten direct uit ColorHunt te testen op alle componenten hieronder.',
+        'hero.helperEn': 'EN Use the ◈ widget to test ColorHunt palettes instantly across all components below.',
 
         'section.typography': 'Typografie',
         'typography.lead': 'Dit is een lead paragraph die opvalt.',
@@ -87,7 +87,7 @@ const TRANSLATIONS = {
         'widget.hint': 'Plak een link om automatisch toe te voegen. Duplicaten lichten op.',
         'widget.empty': 'Nog geen palettes.',
         'widget.selectFromWebsiteDisabled': 'Selecteer van website (binnenkort)',
-        'widget.spotlightTitle': '⬆️ Widget vast net onder de menubalk',
+        'widget.spotlightTitle': '↑ Widget vast net onder de menubalk',
         'widget.spotlightSubtitle': 'Deze widget blijft zichtbaar net onder de menubalk, ook tijdens scrollen, zodat je altijd snel kleuren kunt aanpassen / This widget stays visible just below the menu bar while scrolling so you can always tweak colors quickly.',
         'modal.title': 'Selecteer palettes van ColorHunt',
         'modal.loading': 'Palettes laden...',
@@ -107,8 +107,8 @@ const TRANSLATIONS = {
 
         'hero.lead': 'Test Bootstrap components with ColorHunt color palettes',
         'hero.cta': 'Use the widget just below the menu bar (top-right) to import and apply palettes.',
-        'hero.helperNl': '🇧🇪 Gebruik de 🎨-widget om kleurenpaletten direct uit ColorHunt te testen op alle componenten hieronder.',
-        'hero.helperEn': '🇬🇧 Use the 🎨 widget to test ColorHunt palettes instantly across all components below.',
+        'hero.helperNl': 'NL Gebruik de ◈-widget om kleurenpaletten direct uit ColorHunt te testen op alle componenten hieronder.',
+        'hero.helperEn': 'EN Use the ◈ widget to test ColorHunt palettes instantly across all components below.',
 
         'section.typography': 'Typography',
         'typography.lead': 'This is a standout lead paragraph.',
@@ -177,7 +177,7 @@ const TRANSLATIONS = {
         'widget.hint': 'Paste a link to auto-add. Duplicates will flash.',
         'widget.empty': 'No palettes yet.',
         'widget.selectFromWebsiteDisabled': 'Select from website (coming soon)',
-        'widget.spotlightTitle': '⬆️ Widget fixed below the menu bar',
+        'widget.spotlightTitle': '↑ Widget fixed below the menu bar',
         'widget.spotlightSubtitle': 'Deze widget blijft zichtbaar net onder de menubalk, ook tijdens scrollen, zodat je altijd snel kleuren kunt aanpassen / This widget stays visible just below the menu bar while scrolling so you can always tweak colors quickly.',
         'modal.title': 'Select palettes from ColorHunt',
         'modal.loading': 'Loading palettes...',
@@ -259,7 +259,7 @@ function applyLang(lang) {
 
     const current = document.getElementById('langCurrent');
     if (current) {
-        current.textContent = lang === 'nl' ? '🇧🇪 NL' : '🇬🇧 EN';
+        current.textContent = lang === 'nl' ? 'NL' : 'EN';
     }
 
     document.querySelectorAll('[data-check-lang]').forEach((el) => {

--- a/regex-playground/index.html
+++ b/regex-playground/index.html
@@ -594,12 +594,12 @@
                 'wireframe.testInput': 'Test Input',
                 'wireframe.output': 'Output',
 
-                'sidebar.examples': '📚 Voorbeelden',
-                'sidebar.demoNote': '💡 Demo: Deze voorbeelden zijn ter demonstratie. Klik om te laden!',
+                'sidebar.examples': '☰ Voorbeelden',
+                'sidebar.demoNote': 'ⓘ Demo: Deze voorbeelden zijn ter demonstratie. Klik om te laden!',
 
                 'topbar.homeTitle': 'Terug naar layout keuze',
                 'topbar.tab.match': 'Match',
-                'topbar.share': '🔗 Delen',
+                'topbar.share': '⛓ Delen',
 
                 'panel.regexPattern': 'Regex Pattern',
                 'panel.testInput': 'Test Input',
@@ -609,7 +609,7 @@
                 'flags.caseInsensitive': 'i (niet hoofdlettergevoelig)',
                 'flags.multiline': 'm (multiline)',
 
-                'btn.testPattern': '▶ Test Pattern',
+                'btn.testPattern': '▸ Test Pattern',
                 'input.placeholder': 'Voer je test text hier in...',
 
                 'results.start': 'Klik op "Test Pattern" om te beginnen',
@@ -623,7 +623,7 @@
                 'match.position': 'Positie: {start}-{end}',
                 'match.captured': 'Captured groups:',
 
-                'share.copied': '🔗 Link gekopieerd naar clipboard!',
+                'share.copied': '⛓ Link gekopieerd naar clipboard!',
                 'share.prompt': 'Kopieer deze link:'
             },
             en: {
@@ -649,12 +649,12 @@
                 'wireframe.testInput': 'Test Input',
                 'wireframe.output': 'Output',
 
-                'sidebar.examples': '📚 Examples',
-                'sidebar.demoNote': '💡 Demo: These examples are for demonstration. Click to load!',
+                'sidebar.examples': '☰ Examples',
+                'sidebar.demoNote': 'ⓘ Demo: These examples are for demonstration. Click to load!',
 
                 'topbar.homeTitle': 'Back to layout picker',
                 'topbar.tab.match': 'Match',
-                'topbar.share': '🔗 Share',
+                'topbar.share': '⛓ Share',
 
                 'panel.regexPattern': 'Regex Pattern',
                 'panel.testInput': 'Test Input',
@@ -664,7 +664,7 @@
                 'flags.caseInsensitive': 'i (case insensitive)',
                 'flags.multiline': 'm (multiline)',
 
-                'btn.testPattern': '▶ Test Pattern',
+                'btn.testPattern': '▸ Test Pattern',
                 'input.placeholder': 'Enter your test text here...',
 
                 'results.start': 'Click "Test Pattern" to get started',
@@ -678,7 +678,7 @@
                 'match.position': 'Position: {start}-{end}',
                 'match.captured': 'Captured groups:',
 
-                'share.copied': '🔗 Link copied to clipboard!',
+                'share.copied': '⛓ Link copied to clipboard!',
                 'share.prompt': 'Copy this link:'
             }
         };
@@ -733,8 +733,8 @@
             const lang = getLang();
             return `
                 <select id="${id}" class="lang-select ${contextClass}" aria-label="${t('lang.aria')}">
-                    <option value="nl">🇧🇪 ${t('lang.nl')}</option>
-                    <option value="en">🇬🇧 ${t('lang.en')}</option>
+                    <option value="nl">NL ${t('lang.nl')}</option>
+                    <option value="en">EN ${t('lang.en')}</option>
                 </select>
             `;
         }
@@ -820,7 +820,7 @@
                             <div class="chooser-lang">
                                 ${langSelectHtml('lang-select-chooser', 'lang-select--chooser')}
                             </div>
-                            <h1>🔍 Regex Playground</h1>
+                            <h1>⌕ Regex Playground</h1>
                             <p>${t('chooser.subtitle')}</p>
                         </div>
                         <div class="layout-grid">
@@ -945,7 +945,7 @@
                     <div class="playground ${layoutClass}">
                         <div class="topbar">
                             <div class="topbar-left">
-                                <button class="btn-icon" id="btn-home" title="${t('topbar.homeTitle')}">🏠</button>
+                                <button class="btn-icon" id="btn-home" title="${t('topbar.homeTitle')}">⌂</button>
                                 <span class="project-name">Regex Playground</span>
                             </div>
                             <div class="topbar-center">
@@ -1157,7 +1157,7 @@
                     }
                     
                 } catch (error) {
-                    errorDiv.innerHTML = `<div class="error-message">❌ ${this.escapeHtml(error.message)}</div>`;
+                    errorDiv.innerHTML = `<div class="error-message">✖ ${this.escapeHtml(error.message)}</div>`;
                     resultsDiv.innerHTML = `<div class="empty-state">${t('results.fixRegex')}</div>`;
                     countSpan.textContent = t('match.count.zero');
                 }

--- a/regex-playground/js/components/ExplainPanel.js
+++ b/regex-playground/js/components/ExplainPanel.js
@@ -9,7 +9,7 @@ export class ExplainPanel {
         
         container.innerHTML = `
             <div class="panel-header">
-                <span class="panel-title">🧠 Explanation</span>
+                <span class="panel-title">ℹ Explanation</span>
             </div>
             <div class="explain-content">
                 ${this.explainPattern(this.state.pattern)}

--- a/regex-playground/js/components/LayoutChooser.js
+++ b/regex-playground/js/components/LayoutChooser.js
@@ -75,7 +75,7 @@ export class LayoutChooser {
         const header = document.createElement('div');
         header.className = 'chooser-header';
         header.innerHTML = `
-            <h1>🔍 Regex Playground</h1>
+            <h1>⌕ Regex Playground</h1>
             <p>Kies je preferred layout om te starten</p>
         `;
         

--- a/regex-playground/js/components/RegexEditor.js
+++ b/regex-playground/js/components/RegexEditor.js
@@ -96,7 +96,7 @@ export class RegexEditor {
             errorDiv.style.display = 'none';
             document.querySelector('.regex-input').classList.remove('error');
         } catch (e) {
-            errorDiv.textContent = `❌ ${e.message}`;
+            errorDiv.textContent = `✖ ${e.message}`;
             errorDiv.style.display = 'block';
             document.querySelector('.regex-input').classList.add('error');
         }

--- a/regex-playground/js/components/RegexPlayground.js
+++ b/regex-playground/js/components/RegexPlayground.js
@@ -54,7 +54,7 @@ export class RegexPlayground {
         topbar.className = 'topbar';
         topbar.innerHTML = `
             <div class="topbar-left">
-                <button class="btn-icon" id="btn-home" title="Terug naar layout keuze">🏠</button>
+                <button class="btn-icon" id="btn-home" title="Terug naar layout keuze">⌂</button>
                 <span class="project-name">Regex Playground</span>
             </div>
             <div class="topbar-center">
@@ -65,9 +65,9 @@ export class RegexPlayground {
                 </div>
             </div>
             <div class="topbar-right">
-                <button class="btn-secondary" id="btn-save">💾 Save</button>
-                <button class="btn-secondary" id="btn-share">🔗 Share</button>
-                <button class="btn-icon" id="btn-theme" title="Toggle theme">🌓</button>
+                <button class="btn-secondary" id="btn-save">⬇ Save</button>
+                <button class="btn-secondary" id="btn-share">⛓ Share</button>
+                <button class="btn-icon" id="btn-theme" title="Toggle theme">◐</button>
             </div>
         `;
         
@@ -220,13 +220,13 @@ export class RegexPlayground {
         };
         
         await storage.saveProject(project);
-        alert('✅ Project opgeslagen!');
+        alert('✔ Project opgeslagen!');
     }
 
     shareUrl() {
         const url = urlState.encode(this.state, this.layout);
         navigator.clipboard.writeText(url).then(() => {
-            alert('🔗 Link gekopieerd naar clipboard!');
+            alert('⛓ Link gekopieerd naar clipboard!');
         });
     }
 

--- a/regex-playground/js/components/Sidebar.js
+++ b/regex-playground/js/components/Sidebar.js
@@ -17,7 +17,7 @@ export class Sidebar {
         container.innerHTML = `
             <div class="sidebar-section">
                 <div class="section-header">
-                    <span class="section-title">📁 Projects</span>
+                    <span class="section-title">▤ Projects</span>
                     <button class="btn-tiny" id="btn-new-project">+</button>
                 </div>
                 <div class="project-list" id="project-list">
@@ -30,7 +30,7 @@ export class Sidebar {
             
             <div class="sidebar-section">
                 <div class="section-header">
-                    <span class="section-title">📝 Snippets</span>
+                    <span class="section-title">✎ Snippets</span>
                     <button class="btn-tiny" id="btn-new-snippet">+</button>
                 </div>
                 <div class="snippet-list" id="snippet-list">

--- a/regex-playground/js/components/TestSuite.js
+++ b/regex-playground/js/components/TestSuite.js
@@ -13,7 +13,7 @@ export class TestSuite {
                 <span class="panel-title">Test Suite</span>
                 <div>
                     <button class="btn-secondary" id="btn-add-test">+ Add Test</button>
-                    <button class="btn-primary" id="btn-run-tests">▶ Run All</button>
+                    <button class="btn-primary" id="btn-run-tests">▸ Run All</button>
                 </div>
             </div>
             <div class="test-cases-list" id="test-cases">
@@ -34,8 +34,8 @@ export class TestSuite {
     renderTestCase(testCase, index) {
         const status = testCase.status || 'pending';
         const statusIcon = {
-            'pass': '✅',
-            'fail': '❌',
+            'pass': '✔',
+            'fail': '✖',
             'pending': '⏸'
         }[status];
         

--- a/regex-playground/js/modules/regexEngine.js
+++ b/regex-playground/js/modules/regexEngine.js
@@ -28,7 +28,7 @@ class RegexEngine {
                 const duration = performance.now() - startTime;
                 
                 if (duration > 1000) {
-                    console.warn(`⚠️ Slow regex detected: ${duration.toFixed(2)}ms`);
+                    console.warn(`⚠ Slow regex detected: ${duration.toFixed(2)}ms`);
                 }
                 
                 return {

--- a/src/components/AccessibilityControls.js
+++ b/src/components/AccessibilityControls.js
@@ -60,7 +60,7 @@ const AccessibilityControls = ({ variant = 'floating' }) => {
         aria-label="Toegankelijkheidsinstellingen openen"
       >
         <span aria-hidden="true" className="accessibility-icon" role="presentation">
-          ♿
+          A11Y
         </span>
         <span className="visually-hidden">Toegankelijkheidsopties</span>
       </Button>

--- a/src/components/ThemeSwitcher.js
+++ b/src/components/ThemeSwitcher.js
@@ -177,7 +177,7 @@ const ThemeSwitcher = () => {
           aria-label="Kleurenschema kiezen"
         >
           <span role="img" aria-hidden="true">
-            🎨
+            ◈
           </span>
         </Button>
         
@@ -242,7 +242,7 @@ const ThemeSwitcher = () => {
         aria-label="Kleurenschema kiezen"
       >
         <span role="img" aria-hidden="true">
-          🎨
+          ◈
         </span>
       </Dropdown.Toggle>
       <Dropdown.Menu className="theme-dropdown p-2 shadow-sm border-0">

--- a/zen-writer/index.html
+++ b/zen-writer/index.html
@@ -453,7 +453,7 @@
     <!-- Welcome Modal -->
     <div class="modal-overlay" id="welcomeModal">
         <div class="modal-content">
-            <h2 class="modal-title" data-i18n="welcome.title">👋 Welkom bij Zen Writer</h2>
+            <h2 class="modal-title" data-i18n="welcome.title">✦ Welkom bij Zen Writer</h2>
             <p class="modal-text" data-i18n-html="welcome.text">
                 Klik op de <strong>Focus</strong> knop in de werkbalk voor een volledig wit scherm zonder afleidingen.
                 Druk <strong>Esc</strong> om terug te keren.
@@ -483,25 +483,25 @@
 
     <div class="toolbar">
         <button class="toolbar-btn" id="btnNew" data-i18n-title="toolbar.newTitle" title="Nieuw document (Ctrl+N)">
-            <span>📄</span> <span data-i18n="toolbar.new">Nieuw</span>
+            <span>▤</span> <span data-i18n="toolbar.new">Nieuw</span>
         </button>
         <button class="toolbar-btn" id="btnOpen" data-i18n-title="toolbar.openTitle" title="Open bestand (Ctrl+O)">
-            <span>📂</span> <span data-i18n="toolbar.open">Open</span>
+            <span>▣</span> <span data-i18n="toolbar.open">Open</span>
         </button>
         <button class="toolbar-btn" id="btnSave" data-i18n-title="toolbar.saveTitle" title="Opslaan (Ctrl+S)">
-            <span>💾</span> <span data-i18n="toolbar.save">Opslaan</span>
+            <span>⇩</span> <span data-i18n="toolbar.save">Opslaan</span>
         </button>
 
         <div class="toolbar-divider"></div>
 
         <button class="toolbar-btn" id="btnFullscreen" data-i18n-title="toolbar.focusTitle" title="Fullscreen (F11)">
-            <span>⛶</span> <span data-i18n="toolbar.focus">Focus</span>
+            <span>▣</span> <span data-i18n="toolbar.focus">Focus</span>
         </button>
 
         <div class="toolbar-right">
             <select id="langSelect" class="toolbar-select" aria-label="Language">
-                <option value="nl">🇧🇪 NL</option>
-                <option value="en">🇬🇧 EN</option>
+                <option value="nl">NL</option>
+                <option value="en">EN</option>
             </select>
             <div>
                 <strong data-i18n="shortcuts.title">Shortcuts:</strong>
@@ -520,7 +520,7 @@
     </div>
 
     <div class="fullscreen-hint" id="hint" data-i18n="hint.esc">
-        💡 Druk Esc om te sluiten
+        ⓘ Druk Esc om te sluiten
     </div>
 
     <div class="loading" id="loading" data-i18n="loading">
@@ -539,7 +539,7 @@
             nl: {
                 'page.title': 'Zen Writer - Schrijf zonder afleiding',
 
-                'welcome.title': '👋 Welkom bij Zen Writer',
+                'welcome.title': '✦ Welkom bij Zen Writer',
                 'welcome.text': 'Klik op de <strong>Focus</strong> knop in de werkbalk voor een volledig wit scherm zonder afleidingen. Druk <strong>Esc</strong> om terug te keren.',
                 'welcome.ok': 'Oké, begrepen!',
 
@@ -561,7 +561,7 @@
                 'shortcuts.list': 'Ctrl+B (Bold), Ctrl+I (Italic), Ctrl+U (Underline)',
 
                 'placeholder.title': 'Titel...',
-                'hint.esc': '💡 Druk Esc om te sluiten',
+                'hint.esc': 'ⓘ Druk Esc om te sluiten',
                 'loading': 'Bezig met laden...',
 
                 'alert.unknownFormat': 'Onbekend formaat!',
@@ -574,7 +574,7 @@
             en: {
                 'page.title': 'Zen Writer - Distraction-free writing',
 
-                'welcome.title': '👋 Welcome to Zen Writer',
+                'welcome.title': '✦ Welcome to Zen Writer',
                 'welcome.text': 'Click the <strong>Focus</strong> button in the toolbar for a completely white screen without distractions. Press <strong>Esc</strong> to return.',
                 'welcome.ok': 'Got it!',
 
@@ -596,7 +596,7 @@
                 'shortcuts.list': 'Ctrl+B (Bold), Ctrl+I (Italic), Ctrl+U (Underline)',
 
                 'placeholder.title': 'Title...',
-                'hint.esc': '💡 Press Esc to exit',
+                'hint.esc': 'ⓘ Press Esc to exit',
                 'loading': 'Loading...',
 
                 'alert.unknownFormat': 'Unknown format!',


### PR DESCRIPTION
### Motivation
- Remove pictographic emoji characters from user-facing text and i18n strings to ensure a neutral, consistent UI and improve rendering across platforms.
- Replace emojis with simple symbol alternatives that preserve the original intent (icons, arrows, status markers) while avoiding emoji glyph variability.

### Description
- Replaced emoji characters in translation strings and UI labels across `regex-playground`, `zen-writer`, and `colorhunt` with neutral symbols (examples: `▶`→`▸`, `👋`→`✦`, `🎨`→`◈`, `💡`→`ⓘ`, `🔗`→`⛓`, status icons `✅/❌`→`✔/✖`, etc.).
- Updated runtime language indicators and language dropdowns to use `NL`/`EN` abbreviations instead of flag emojis and adjusted related `applyLang` logic text content.
- Replaced emoji markers used in components such as `ThemeSwitcher`, `AccessibilityControls`, sidebar/topbar/test status, error messages, and regex engine warning text with symbol alternatives.
- Files modified include (not exhaustive): `colorhunt/index.html`, `colorhunt/script.js`, `regex-playground/index.html`, `regex-playground/js/components/{ExplainPanel,LayoutChooser,RegexEditor,RegexPlayground,Sidebar,TestSuite}.js`, `regex-playground/js/modules/regexEngine.js`, `src/components/{ThemeSwitcher,AccessibilityControls}.js`, and `zen-writer/index.html`.

### Testing
- Ran a repository build with `npm run build` from the project root and the build completed successfully.
- Performed a character-range scan for pictographic/emoji characters using ripgrep (e.g. `rg -nP "\p{Extended_Pictographic}" ...`) on the edited areas to verify removals and reviewed remaining non-emoji symbols; the scan confirmed intended replacements.
- Ran an additional file/regression check for a set of edited files to confirm the updated strings render in source without emoji and no runtime errors were produced during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e09d543a0c832c85204c7a14caa01d)